### PR TITLE
Implemented apiPublishUpdateSwitch.

### DIFF
--- a/api/publish.go
+++ b/api/publish.go
@@ -168,7 +168,67 @@ func apiPublishRepoOrSnapshot(c *gin.Context) {
 
 // PUT /publish/:prefix/:distribution
 func apiPublishUpdateSwitch(c *gin.Context) {
-	c.JSON(400, gin.H{})
+	param := parseEscapedPath(c.Params.ByName("prefix"))
+	storage, prefix := deb.ParsePrefix(param)
+	distribution := c.Params.ByName("distribution")
+
+	var b struct {
+		ForceOverwrite bool
+		Signing        SigningOptions
+	}
+
+	if !c.Bind(&b) {
+		return
+	}
+
+	signer, err := getSigner(&b.Signing)
+	if err != nil {
+		c.Fail(500, fmt.Errorf("unable to initialize GPG signer: %s", err))
+		return
+	}
+
+	collection := context.CollectionFactory().PublishedRepoCollection()
+	collection.Lock()
+	defer collection.Unlock()
+
+	published, err := collection.ByStoragePrefixDistribution(storage, prefix, distribution)
+	if err != nil {
+		c.Fail(500, fmt.Errorf("unable to update: %s", err))
+		return
+	}
+	if published.SourceKind != "local" {
+		c.Fail(500, fmt.Errorf("unable to update: not a local repository"))
+		return
+	}
+
+	err = collection.LoadComplete(published, context.CollectionFactory())
+	if err != nil {
+		c.Fail(500, fmt.Errorf("unable to update: %s", err))
+		return
+	}
+
+	components := published.Components()
+	for _, component := range components {
+		published.UpdateLocalRepo(component)
+	}
+
+	err = published.Publish(context.PackagePool(), context, context.CollectionFactory(), signer, context.Progress(), b.ForceOverwrite)
+	if err != nil {
+		c.Fail(500, fmt.Errorf("unable to update: %s", err))
+	}
+
+	err = collection.Update(published)
+	if err != nil {
+		c.Fail(500, fmt.Errorf("unable to save to DB: %s", err))
+	}
+
+	err = collection.CleanupPrefixComponentFiles(published.Prefix, components,
+		context.GetPublishedStorage(storage), context.CollectionFactory(), context.Progress())
+	if err != nil {
+		c.Fail(500, fmt.Errorf("unable to update: %s", err))
+	}
+
+	c.JSON(200, published)
 }
 
 // DELETE /publish/:prefix/:distribution


### PR DESCRIPTION
I implemented `apiPublishUpdateSwitch` for updating repositories through the REST API. This has been working fine for me over several days of relatively heavy testing. Most of this logic is copied verbatim from the command-line `aptly repo update` call. Ideally the common code could be factored out into a standalone update repository function that is used in both places.

I only made this change myself because I needed the ability to update a published (local) repository through the REST API and couldn't wait for it to be implemented. You're welcome to ignore this if you have a better implementation in mind.

This is the first time I have ever written Go, so no promises on the quality. :smile:  