### PR TITLE
Update dependency definition in conflicts (fixes #185)

### DIFF
--- a/deb/import.go
+++ b/deb/import.go
@@ -140,7 +140,7 @@ func ImportPackageFiles(list *PackageList, packageFiles []string, forceReplace b
 		}
 
 		if forceReplace {
-			conflictingPackages := list.Search(Dependency{Pkg: p.Name, Version: p.Version, Architecture: p.Architecture}, true)
+			conflictingPackages := list.Search(Dependency{Pkg: p.Name, Version: p.Version, Relation: VersionEqual, Architecture: p.Architecture}, true)
 			for _, cp := range conflictingPackages {
 				reporter.Removed("%s removed due to conflict with package being added", cp)
 				list.Remove(cp)


### PR DESCRIPTION
The dependency specified when looking for conflicting packages
does not take into account the package version, as by default the
Relation field in the Dependency structure is set to VersionDontCare.
This should fix #185.