### PR TITLE
d-i requires the Suite field in order to validate a mirror.

### DIFF
--- a/deb/publish.go
+++ b/deb/publish.go
@@ -624,6 +624,7 @@ func (p *PublishedRepo) Publish(packagePool aptly.PackagePool, publishedStorageP
 	release := make(Stanza)
 	release["Origin"] = p.GetOrigin()
 	release["Label"] = p.GetLabel()
+	release["Suite"] = p.Distribution
 	release["Codename"] = p.Distribution
 	release["Date"] = time.Now().UTC().Format("Mon, 2 Jan 2006 15:04:05 MST")
 	release["Architectures"] = strings.Join(utils.StrSlicesSubstract(p.Architectures, []string{"source"}), " ")

--- a/system/t06_publish/PublishRepo12Test_release
+++ b/system/t06_publish/PublishRepo12Test_release
@@ -1,5 +1,6 @@
 Origin: . maverick
 Label: . maverick
+Suite: maverick
 Codename: maverick
 Architectures: i386
 Components: main

--- a/system/t06_publish/PublishRepo15Test_release
+++ b/system/t06_publish/PublishRepo15Test_release
@@ -1,5 +1,6 @@
 Origin: . maverick
 Label: label15
+Suite: maverick
 Codename: maverick
 Architectures: i386
 Components: contrib

--- a/system/t06_publish/PublishRepo17Test_release
+++ b/system/t06_publish/PublishRepo17Test_release
@@ -1,5 +1,6 @@
 Origin: . maverick
 Label: . maverick
+Suite: maverick
 Codename: maverick
 Architectures: i386
 Components: contrib main

--- a/system/t06_publish/PublishRepo1Test_release
+++ b/system/t06_publish/PublishRepo1Test_release
@@ -1,5 +1,6 @@
 Origin: . maverick
 Label: . maverick
+Suite: maverick
 Codename: maverick
 Architectures: i386
 Components: main

--- a/system/t06_publish/PublishSnapshot13Test_release
+++ b/system/t06_publish/PublishSnapshot13Test_release
@@ -1,5 +1,6 @@
 Origin: . maverick
 Label: . maverick
+Suite: maverick
 Codename: maverick
 Architectures: amd64 i386
 Components: main

--- a/system/t06_publish/PublishSnapshot15Test_release
+++ b/system/t06_publish/PublishSnapshot15Test_release
@@ -1,5 +1,6 @@
 Origin: . maverick
 Label: . maverick
+Suite: maverick
 Codename: maverick
 Architectures: amd64 i386
 Components: main

--- a/system/t06_publish/PublishSnapshot16Test_release
+++ b/system/t06_publish/PublishSnapshot16Test_release
@@ -1,5 +1,6 @@
 Origin: . maverick
 Label: . maverick
+Suite: maverick
 Codename: maverick
 Architectures: amd64 i386
 Components: main

--- a/system/t06_publish/PublishSnapshot17Test_release
+++ b/system/t06_publish/PublishSnapshot17Test_release
@@ -1,5 +1,6 @@
 Origin: . maverick
 Label: . maverick
+Suite: maverick
 Codename: maverick
 Architectures: i386
 Components: main

--- a/system/t06_publish/PublishSnapshot1Test_release
+++ b/system/t06_publish/PublishSnapshot1Test_release
@@ -1,5 +1,6 @@
 Origin: . maverick
 Label: . maverick
+Suite: maverick
 Codename: maverick
 Date: Fri, 31 Jan 2014 14:18:52 UTC
 Architectures: amd64 i386

--- a/system/t06_publish/PublishSnapshot24Test_release
+++ b/system/t06_publish/PublishSnapshot24Test_release
@@ -1,5 +1,6 @@
 Origin: aptly24
 Label: . squeeze
+Suite: squeeze
 Codename: squeeze
 Architectures: amd64 i386
 Components: main

--- a/system/t06_publish/PublishSnapshot26Test_release
+++ b/system/t06_publish/PublishSnapshot26Test_release
@@ -1,5 +1,6 @@
 Origin: . maverick
 Label: . maverick
+Suite: maverick
 Codename: maverick
 Architectures: amd64 i386
 Components: contrib main

--- a/system/t06_publish/PublishSnapshot2Test_release
+++ b/system/t06_publish/PublishSnapshot2Test_release
@@ -1,5 +1,6 @@
 Origin: . squeeze
 Label: . squeeze
+Suite: squeeze
 Codename: squeeze
 Architectures: amd64 i386
 Components: main

--- a/system/t06_publish/PublishSnapshot35Test_release
+++ b/system/t06_publish/PublishSnapshot35Test_release
@@ -1,5 +1,6 @@
 Origin: . squeeze
 Label: . squeeze
+Suite: squeeze
 Codename: squeeze
 Date: Tue, 30 Sep 2014 15:35:22 UTC
 Architectures: amd64 i386

--- a/system/t06_publish/PublishSnapshot3Test_release
+++ b/system/t06_publish/PublishSnapshot3Test_release
@@ -1,5 +1,6 @@
 Origin: . squeeze
 Label: . squeeze
+Suite: squeeze
 Codename: squeeze
 Architectures: amd64 i386
 Components: contrib

--- a/system/t06_publish/PublishSnapshot4Test_release
+++ b/system/t06_publish/PublishSnapshot4Test_release
@@ -1,5 +1,6 @@
 Origin: . squeeze
 Label: . squeeze
+Suite: squeeze
 Codename: squeeze
 Architectures: i386
 Components: main

--- a/system/t06_publish/PublishSwitch1Test_release
+++ b/system/t06_publish/PublishSwitch1Test_release
@@ -1,5 +1,6 @@
 Origin: . maverick
 Label: . maverick
+Suite: maverick
 Codename: maverick
 Architectures: amd64 i386
 Components: main

--- a/system/t06_publish/PublishSwitch8Test_release
+++ b/system/t06_publish/PublishSwitch8Test_release
@@ -1,5 +1,6 @@
 Origin: . maverick
 Label: . maverick
+Suite: maverick
 Codename: maverick
 Architectures: amd64 i386
 Components: a b c

--- a/system/t06_publish/PublishUpdate1Test_release
+++ b/system/t06_publish/PublishUpdate1Test_release
@@ -1,5 +1,6 @@
 Origin: . maverick
 Label: . maverick
+Suite: maverick
 Codename: maverick
 Architectures: i386
 Components: main

--- a/system/t06_publish/S3Publish1Test_release
+++ b/system/t06_publish/S3Publish1Test_release
@@ -1,5 +1,6 @@
 Origin: . maverick
 Label: . maverick
+Suite: maverick
 Codename: maverick
 Date: Wed, 1 Oct 2014 08:48:48 UTC
 Architectures: i386

--- a/system/t06_publish/S3Publish2Test_release
+++ b/system/t06_publish/S3Publish2Test_release
@@ -1,5 +1,6 @@
 Origin: . maverick
 Label: . maverick
+Suite: maverick
 Codename: maverick
 Date: Wed, 1 Oct 2014 09:13:14 UTC
 Architectures: i386

--- a/system/t06_publish/S3Publish3Test_release
+++ b/system/t06_publish/S3Publish3Test_release
@@ -1,5 +1,6 @@
 Origin: . maverick
 Label: . maverick
+Suite: maverick
 Codename: maverick
 Date: Wed, 1 Oct 2014 09:16:49 UTC
 Architectures: amd64 i386


### PR DESCRIPTION
Debian's installer validates a mirror by downloading a Release,
and then cross-checking it based on its Codename and Suite.  Without
a Suite field, the installer becomes unhappy (e.g. segfaults) and
won't continue the install.

Making the Codename and Suite the same validates with no problem.