### PR TITLE
Add basic support for non-Amazon S3

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -322,7 +322,7 @@ func (context *AptlyContext) GetPublishedStorage(name string) aptly.PublishedSto
 
 			var err error
 			publishedStorage, err = s3.NewPublishedStorage(params.AccessKeyID, params.SecretAccessKey,
-				params.Region, params.Bucket, params.ACL, params.Prefix, params.StorageClass,
+				params.Region, params.S3endpoint, params.Bucket, params.ACL, params.Prefix, params.StorageClass,
 				params.EncryptionMethod, params.PlusWorkaround)
 			if err != nil {
 				Fatal(err)

--- a/man/aptly.1
+++ b/man/aptly.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "APTLY" "1" "February 2015" "" ""
+.TH "APTLY" "1" "March 2015" "" ""
 .
 .SH "NAME"
 \fBaptly\fR \- Debian repository management tool
@@ -10,7 +10,7 @@
 Common command format:
 .
 .P
-\fBaptly\fR [\fIglobal options\fR\|\.\|\.\|\.] \fIcommand\fR \fIsubcommand\fR [\fIoptions\fR\|\.\|\.\|\.] \fIarguments\fR
+\fBaptly\fR [\fIglobal options\fR\.\.\.] \fIcommand\fR \fIsubcommand\fR [\fIoptions\fR\.\.\.] \fIarguments\fR
 .
 .P
 aptly has integrated help that matches contents of this manual page, to get help, prepend \fBhelp\fR to command name:
@@ -22,7 +22,7 @@ aptly has integrated help that matches contents of this manual page, to get help
 aptly is a tool to create partial and full mirrors of remote repositories, manage local repositories, filter them, merge, upgrade individual packages, take snapshots and publish them back as Debian repositories\.
 .
 .P
-aptly\(cqs goal is to establish repeatability and controlled changes in a package\-centric environment\. aptly allows one to fix a set of packages in a repository, so that package installation and upgrade becomes deterministic\. At the same time aptly allows one to perform controlled, fine\-grained changes in repository contents to transition your package environment to new version\.
+aptly\'s goal is to establish repeatability and controlled changes in a package\-centric environment\. aptly allows one to fix a set of packages in a repository, so that package installation and upgrade becomes deterministic\. At the same time aptly allows one to perform controlled, fine\-grained changes in repository contents to transition your package environment to new version\.
 .
 .SH "CONFIGURATION"
 aptly looks for configuration file first in \fB~/\.aptly\.conf\fR then in \fB/etc/aptly\.conf\fR and, if no config file found, new one is created in home directory\. If \fB\-config=\fR flag is specified, aptly would use config file at specified location\. Also aptly needs root directory for database, package and published repository storage\. If not specified, directory defaults to \fB~/\.aptly\fR, it will be created if missing\.
@@ -51,6 +51,7 @@ Configuration file is stored in JSON format (default values shown below):
   "S3PublishEndpoints": {
     "test": {
       "region": "us\-east\-1",
+      "s3endpoint": "",
       "bucket": "repo",
       "awsAccessKeyID": "",
       "awsSecretAccessKey": "",
@@ -115,11 +116,11 @@ follow dependency from binary package to source package
 .
 .TP
 \fBgpgDisableSign\fR
-don\(cqt sign published repositories with gpg(1), also can be disabled on per\-repo basis using \fB\-skip\-signing\fR flag when publishing
+don\'t sign published repositories with gpg(1), also can be disabled on per\-repo basis using \fB\-skip\-signing\fR flag when publishing
 .
 .TP
 \fBgpgDisableVerify\fR
-don\(cqt verify remote mirrors with gpg(1), also can be disabled on per\-mirror basis using \fB\-ignore\-signatures\fR flag when creating and updating mirrors
+don\'t verify remote mirrors with gpg(1), also can be disabled on per\-mirror basis using \fB\-ignore\-signatures\fR flag when creating and updating mirrors
 .
 .TP
 \fBdownloadSourcePackages\fR
@@ -133,12 +134,20 @@ specifies paramaters for short PPA url expansion, if left blank they default to 
 \fBS3PublishEndpoints\fR
 configuration of Amazon S3 publishing endpoints (see below)
 .
+.TP
+\fBSwiftPublishEndpoints\fR
+configuration of OpenStack Swift publishing endpoints (see below)
+.
 .SH "S3 PUBLISHING ENDPOINTS"
 aptly could be configured to publish repository directly to Amazon S3\. First, publishing endpoints should be described in aptly configuration file\. Each endpoint has name and associated settings:
 .
 .TP
 \fBregion\fR
 Amazon region for S3 bucket (e\.g\. \fBus\-east\-1\fR)
+.
+.TP
+\fBs3endpoint\fR
+Custom S3 Endpoint url for non\-Amazon S3, leave empty to use Amazon\.
 .
 .TP
 \fBbucket\fR
@@ -221,22 +230,22 @@ syntax is the same as for dependency conditions, but instead of package name fie
 .P
 Supported fields:
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 all field names from Debian package control files are supported except for \fBFilename\fR, \fBMD5sum\fR, \fBSHA1\fR, \fBSHA256\fR, \fBSize\fR, \fBFiles\fR, \fBChecksums\-SHA1\fR, \fBChecksums\-SHA256\fR\.
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB$Source\fR is a name of source package (for binary packages)
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB$SourceVersion\fR is a version of source package
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB$Architecture\fR is \fBArchitecture\fR for binary packages and \fBsource\fR for source packages, when matching with equal (\fB=\fR) operator, package with \fBany\fR architecture matches all architectures but \fBsource\fR\.
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB$Version\fR has the same value as \fBVersion\fR, but comparison operators use Debian version precedence rules
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB$PackageType\fR is \fBdeb\fR for binary packages and \fBsource\fR for source packages
 .
 .IP "" 0
@@ -261,7 +270,7 @@ pattern matching, like shell patterns, supported special symbols are: \fB[^]?*\f
 regular expression matching, e\.g\.: \fBName (~ \.*\-dev)\fR
 .
 .P
-Simple terms could be combined into more complex queries using operators \fB,\fR (and), \fB|\fR (or) and \fB!\fR (not), parentheses \fB()\fR are used to change operator precedence\. Match value could be enclosed in single (\fB\(cq\fR) or double (\fB"\fR) quotes if required to resolve ambiguity, quotes inside quoted string should escaped with slash (\fB\e\fR)\.
+Simple terms could be combined into more complex queries using operators \fB,\fR (and), \fB|\fR (or) and \fB!\fR (not), parentheses \fB()\fR are used to change operator precedence\. Match value could be enclosed in single (\fB\'\fR) or double (\fB"\fR) quotes if required to resolve ambiguity, quotes inside quoted string should escaped with slash (\fB\e\fR)\.
 .
 .P
 Examples:
@@ -298,7 +307,7 @@ matches all packages that provide \fBmail\-transport\fR with name that has no su
 When specified on command line, query may have to be quoted according to shell rules, so that it stays single argument:
 .
 .P
-\fBaptly repo import percona stable \(cqmysql\-client (>= 3\.6)\(cq\fR
+\fBaptly repo import percona stable \'mysql\-client (>= 3\.6)\'\fR
 .
 .SH "GLOBAL OPTIONS"
 .
@@ -312,7 +321,7 @@ location of configuration file (default locations are /etc/aptly\.conf, ~/\.aptl
 .
 .TP
 \-\fBdep\-follow\-all\-variants\fR=false
-when processing dependencies, follow a & b if depdency is \(cqa|b\(cq
+when processing dependencies, follow a & b if depdency is \'a|b\'
 .
 .TP
 \-\fBdep\-follow\-recommends\fR=false
@@ -327,10 +336,10 @@ when processing dependencies, follow from binary to Source packages
 when processing dependencies, follow Suggests
 .
 .SH "CREATE NEW MIRROR"
-\fBaptly\fR \fBmirror\fR \fBcreate\fR \fIname\fR \fIarchive url\fR \fIdistribution\fR [\fIcomponent1\fR \|\.\|\.\|\.]
+\fBaptly\fR \fBmirror\fR \fBcreate\fR \fIname\fR \fIarchive url\fR \fIdistribution\fR [\fIcomponent1\fR \.\.\.]
 .
 .P
-Creates mirror \fIname\fR of remote repository, aptly supports both regular and flat Debian repositories exported via HTTP and FTP\. aptly would try download Release file from remote repository and verify its\(cq signature\. Command line format resembles apt utlitily sources\.list(5)\.
+Creates mirror \fIname\fR of remote repository, aptly supports both regular and flat Debian repositories exported via HTTP and FTP\. aptly would try download Release file from remote repository and verify its\' signature\. Command line format resembles apt utlitily sources\.list(5)\.
 .
 .P
 PPA urls could specified in short format:
@@ -523,7 +532,7 @@ Example:
 .
 .nf
 
-$ aptly mirror search wheezy\-main \(cq$Architecture (i386), Name (% *\-dev)\(cq
+$ aptly mirror search wheezy\-main \'$Architecture (i386), Name (% *\-dev)\'
 .
 .fi
 .
@@ -560,7 +569,7 @@ when adding package that conflicts with existing package, remove existing packag
 remove files that have been imported successfully into repository
 .
 .SH "COPY PACKAGES BETWEEN LOCAL REPOSITORIES"
-\fBaptly\fR \fBrepo\fR \fBcopy\fR \fIsrc\-name\fR \fIdst\-name\fR \fIpackage\-query\fR \fB\|\.\|\.\|\.\fR
+\fBaptly\fR \fBrepo\fR \fBcopy\fR \fIsrc\-name\fR \fIdst\-name\fR \fIpackage\-query\fR \fB\.\.\.\fR
 .
 .P
 Command copy copies packages matching \fIpackage\-query\fR from local repo \fIsrc\-name\fR to local repo \fIdst\-name\fR\.
@@ -569,14 +578,14 @@ Command copy copies packages matching \fIpackage\-query\fR from local repo \fIsr
 Example:
 .
 .P
-$ aptly repo copy testing stable \(cqmyapp (=0\.1\.12)\(cq
+$ aptly repo copy testing stable \'myapp (=0\.1\.12)\'
 .
 .P
 Options:
 .
 .TP
 \-\fBdry\-run\fR=false
-don\(cqt copy, just show what would be copied
+don\'t copy, just show what would be copied
 .
 .TP
 \-\fBwith\-deps\fR=false
@@ -656,7 +665,7 @@ default component when publishing
 default distribution when publishing
 .
 .SH "IMPORT PACKAGES FROM MIRROR TO LOCAL REPOSITORY"
-\fBaptly\fR \fBrepo\fR \fBimport\fR \fIsrc\-mirror\fR \fIdst\-repo\fR \fIpackage\-query\fR \fB\|\.\|\.\|\.\fR
+\fBaptly\fR \fBrepo\fR \fBimport\fR \fIsrc\-mirror\fR \fIdst\-repo\fR \fIpackage\-query\fR \fB\.\.\.\fR
 .
 .P
 Command import looks up packages matching \fIpackage\-query\fR in mirror \fIsrc\-mirror\fR and copies them to local repo \fIdst\-repo\fR\.
@@ -672,7 +681,7 @@ Options:
 .
 .TP
 \-\fBdry\-run\fR=false
-don\(cqt import, just show what would be imported
+don\'t import, just show what would be imported
 .
 .TP
 \-\fBwith\-deps\fR=false
@@ -698,7 +707,7 @@ Options:
 display list in machine\-readable format
 .
 .SH "MOVE PACKAGES BETWEEN LOCAL REPOSITORIES"
-\fBaptly\fR \fBrepo\fR \fBmove\fR \fIsrc\-name\fR \fIdst\-name\fR \fIpackage\-query\fR \fB\|\.\|\.\|\.\fR
+\fBaptly\fR \fBrepo\fR \fBmove\fR \fIsrc\-name\fR \fIdst\-name\fR \fIpackage\-query\fR \fB\.\.\.\fR
 .
 .P
 Command move moves packages matching \fIpackage\-query\fR from local repo \fIsrc\-name\fR to local repo \fIdst\-name\fR\.
@@ -707,37 +716,37 @@ Command move moves packages matching \fIpackage\-query\fR from local repo \fIsrc
 Example:
 .
 .P
-$ aptly repo move testing stable \(cqmyapp (=0\.1\.12)\(cq
+$ aptly repo move testing stable \'myapp (=0\.1\.12)\'
 .
 .P
 Options:
 .
 .TP
 \-\fBdry\-run\fR=false
-don\(cqt move, just show what would be moved
+don\'t move, just show what would be moved
 .
 .TP
 \-\fBwith\-deps\fR=false
 follow dependencies when processing package\-spec
 .
 .SH "REMOVE PACKAGES FROM LOCAL REPOSITORY"
-\fBaptly\fR \fBrepo\fR \fBremove\fR \fIname\fR \fIpackage\-query\fR \fB\|\.\|\.\|\.\fR
+\fBaptly\fR \fBrepo\fR \fBremove\fR \fIname\fR \fIpackage\-query\fR \fB\.\.\.\fR
 .
 .P
-Commands removes packages matching \fIpackage\-query\fR from local repository \fIname\fR\. If removed packages are not referenced by other repos or snapshots, they can be removed completely (including files) by running \(cqaptly db cleanup\(cq\.
+Commands removes packages matching \fIpackage\-query\fR from local repository \fIname\fR\. If removed packages are not referenced by other repos or snapshots, they can be removed completely (including files) by running \'aptly db cleanup\'\.
 .
 .P
 Example:
 .
 .P
-$ aptly repo remove testing \(cqmyapp (=0\.1\.12)\(cq
+$ aptly repo remove testing \'myapp (=0\.1\.12)\'
 .
 .P
 Options:
 .
 .TP
 \-\fBdry\-run\fR=false
-don\(cqt remove, just show what would be removed
+don\'t remove, just show what would be removed
 .
 .SH "SHOW DETAILS ABOUT LOCAL REPOSITORY"
 \fBaptly\fR \fBrepo\fR \fBshow\fR \fIname\fR
@@ -780,7 +789,7 @@ Example:
 .
 .nf
 
-$ aptly repo search my\-software \(cq$Architecture (i386), Name (% *\-dev)\(cq
+$ aptly repo search my\-software \'$Architecture (i386), Name (% *\-dev)\'
 .
 .fi
 .
@@ -832,7 +841,7 @@ display list in machine\-readable format
 .
 .TP
 \-\fBsort\fR=name
-display list in \(cqname\(cq or creation \(cqtime\(cq order
+display list in \'name\' or creation \'time\' order
 .
 .SH "SHOWS DETAILS ABOUT SNAPSHOT"
 \fBaptly\fR \fBsnapshot\fR \fBshow\fR \fIname\fR
@@ -861,7 +870,7 @@ Options:
 show list of packages
 .
 .SH "VERIFY DEPENDENCIES IN SNAPSHOT"
-\fBaptly\fR \fBsnapshot\fR \fBverify\fR \fIname\fR [\fIsource\fR \|\.\|\.\|\.]
+\fBaptly\fR \fBsnapshot\fR \fBverify\fR \fIname\fR [\fIsource\fR \.\.\.]
 .
 .P
 Verify does dependency resolution in snapshot \fIname\fR, possibly using additional snapshots \fIsource\fR as dependency sources\. All unsatisfied dependencies are printed\.
@@ -880,10 +889,10 @@ $ aptly snapshot verify wheezy\-main wheezy\-contrib wheezy\-non\-free
 .IP "" 0
 .
 .SH "PULL PACKAGES FROM ANOTHER SNAPSHOT"
-\fBaptly\fR \fBsnapshot\fR \fBpull\fR \fIname\fR \fIsource\fR \fIdestination\fR \fIpackage\-query\fR \fB\|\.\|\.\|\.\fR
+\fBaptly\fR \fBsnapshot\fR \fBpull\fR \fIname\fR \fIsource\fR \fIdestination\fR \fIpackage\-query\fR \fB\.\.\.\fR
 .
 .P
-Command pull pulls new packages along with its\(cq dependencies to snapshot \fIname\fR from snapshot \fIsource\fR\. Pull can upgrade package version in \fIname\fR with versions from \fIsource\fR following dependencies\. New snapshot \fIdestination\fR is created as a result of this process\. Packages could be specified simply as \(cqpackage\-name\(cq or as package queries\.
+Command pull pulls new packages along with its\' dependencies to snapshot \fIname\fR from snapshot \fIsource\fR\. Pull can upgrade package version in \fIname\fR with versions from \fIsource\fR following dependencies\. New snapshot \fIdestination\fR is created as a result of this process\. Packages could be specified simply as \'package\-name\' or as package queries\.
 .
 .P
 Example:
@@ -907,15 +916,15 @@ pull all the packages that satisfy the dependency version requirements
 .
 .TP
 \-\fBdry\-run\fR=false
-don\(cqt create destination snapshot, just show what would be pulled
+don\'t create destination snapshot, just show what would be pulled
 .
 .TP
 \-\fBno\-deps\fR=false
-don\(cqt process dependencies, just pull listed packages
+don\'t process dependencies, just pull listed packages
 .
 .TP
 \-\fBno\-remove\fR=false
-don\(cqt remove other package versions when pulling package
+don\'t remove other package versions when pulling package
 .
 .SH "DIFFERENCE BETWEEN TWO SNAPSHOTS"
 \fBaptly\fR \fBsnapshot\fR \fBdiff\fR \fIname\-a\fR \fIname\-b\fR
@@ -941,10 +950,10 @@ Options:
 .
 .TP
 \-\fBonly\-matching\fR=false
-display diff only for matching packages (don\(cqt display missing packages)
+display diff only for matching packages (don\'t display missing packages)
 .
 .SH "MERGES SNAPSHOTS"
-\fBaptly\fR \fBsnapshot\fR \fBmerge\fR \fIdestination\fR \fIsource\fR [\fIsource\fR\|\.\|\.\|\.]
+\fBaptly\fR \fBsnapshot\fR \fBmerge\fR \fIdestination\fR \fIsource\fR [\fIsource\fR\.\.\.]
 .
 .P
 Merge command merges several \fIsource\fR snapshots into one \fIdestination\fR snapshot\. Merge happens from left to right\. By default, packages with the same name\-architecture pair are replaced during merge (package from latest snapshot on the list wins)\. If run with only one source snapshot, merge copies \fIsource\fR into \fIdestination\fR\.
@@ -971,13 +980,13 @@ use only the latest version of each package
 .
 .TP
 \-\fBno\-remove\fR=false
-don\(cqt remove duplicate arch/name packages
+don\'t remove duplicate arch/name packages
 .
 .SH "DELETE SNAPSHOT"
 \fBaptly\fR \fBsnapshot\fR \fBdrop\fR \fIname\fR
 .
 .P
-Drop removes information about a snapshot\. If snapshot is published, it can\(cqt be dropped\.
+Drop removes information about a snapshot\. If snapshot is published, it can\'t be dropped\.
 .
 .P
 Example:
@@ -1024,7 +1033,7 @@ Example:
 .
 .nf
 
-$ aptly snapshot search wheezy\-main \(cq$Architecture (i386), Name (% *\-dev)\(cq
+$ aptly snapshot search wheezy\-main \'$Architecture (i386), Name (% *\-dev)\'
 .
 .fi
 .
@@ -1038,10 +1047,10 @@ Options:
 include dependencies into search results
 .
 .SH "FILTER PACKAGES IN SNAPSHOT PRODUCING ANOTHER SNAPSHOT"
-\fBaptly\fR \fBsnapshot\fR \fBfilter\fR \fIsource\fR \fIdestination\fR \fIpackage\-query\fR \fB\|\.\|\.\|\.\fR
+\fBaptly\fR \fBsnapshot\fR \fBfilter\fR \fIsource\fR \fIdestination\fR \fIpackage\-query\fR \fB\.\.\.\fR
 .
 .P
-Command filter does filtering in snapshot \fIsource\fR, producing another snapshot \fIdestination\fR\. Packages could be specified simply as \(cqpackage\-name\(cq or as package queries\.
+Command filter does filtering in snapshot \fIsource\fR, producing another snapshot \fIdestination\fR\. Packages could be specified simply as \'package\-name\' or as package queries\.
 .
 .P
 Example:
@@ -1050,7 +1059,7 @@ Example:
 .
 .nf
 
-$ aptly snapshot filter wheezy\-main wheezy\-required \(cqPriorioty (required)\(cq
+$ aptly snapshot filter wheezy\-main wheezy\-required \'Priorioty (required)\'
 .
 .fi
 .
@@ -1192,7 +1201,7 @@ GPG secret keyring to use (instead of default)
 .
 .TP
 \-\fBskip\-signing\fR=false
-don\(cqt sign Release files with GPG
+don\'t sign Release files with GPG
 .
 .SH "PUBLISH SNAPSHOT"
 \fBaptly\fR \fBpublish\fR \fBsnapshot\fR \fIname\fR [[\fIendpoint\fR:]\fIprefix\fR]
@@ -1275,7 +1284,7 @@ GPG secret keyring to use (instead of default)
 .
 .TP
 \-\fBskip\-signing\fR=false
-don\(cqt sign Release files with GPG
+don\'t sign Release files with GPG
 .
 .SH "UPDATE PUBLISHED REPOSITORY BY SWITCHING TO NEW SNAPSHOT"
 \fBaptly\fR \fBpublish\fR \fBswitch\fR \fIdistribution\fR [[\fIendpoint\fR:]\fIprefix\fR] \fInew\-snapshot\fR
@@ -1349,7 +1358,7 @@ GPG secret keyring to use (instead of default)
 .
 .TP
 \-\fBskip\-signing\fR=false
-don\(cqt sign Release files with GPG
+don\'t sign Release files with GPG
 .
 .SH "UPDATE PUBLISHED LOCAL REPOSITORY"
 \fBaptly\fR \fBpublish\fR \fBupdate\fR \fIdistribution\fR [[\fIendpoint\fR:]\fIprefix\fR]
@@ -1406,7 +1415,7 @@ GPG secret keyring to use (instead of default)
 .
 .TP
 \-\fBskip\-signing\fR=false
-don\(cqt sign Release files with GPG
+don\'t sign Release files with GPG
 .
 .SH "SEARCH FOR PACKAGES MATCHING QUERY"
 \fBaptly\fR \fBpackage\fR \fBsearch\fR \fIpackage\-query\fR
@@ -1421,7 +1430,7 @@ Example:
 .
 .nf
 
-$ aptly package search \(cq$Architecture (i386), Name (% *\-dev)\(cq
+$ aptly package search \'$Architecture (i386), Name (% *\-dev)\'
 .
 .fi
 .
@@ -1440,7 +1449,7 @@ Example:
 .
 .nf
 
-$ aptly package show nginx\-light_1\.2\.1\-2\.2+wheezy2_i386\(cq
+$ aptly package show nginx\-light_1\.2\.1\-2\.2+wheezy2_i386\'
 .
 .fi
 .
@@ -1461,7 +1470,7 @@ display information about mirrors, snapshots and local repos referencing this pa
 \fBaptly\fR \fBdb\fR \fBcleanup\fR
 .
 .P
-Database cleanup removes information about unreferenced packages and removes files in the package pool that aren\(cqt used by packages anymore
+Database cleanup removes information about unreferenced packages and removes files in the package pool that aren\'t used by packages anymore
 .
 .P
 Example:
@@ -1473,7 +1482,7 @@ $ aptly db cleanup
 \fBaptly\fR \fBdb\fR \fBrecover\fR
 .
 .P
-Database recover does its\(cq best to recover the database after a crash\. It is recommended to backup the DB before running recover\.
+Database recover does its\' best to recover the database after a crash\. It is recommended to backup the DB before running recover\.
 .
 .P
 Example:
@@ -1485,7 +1494,7 @@ $ aptly db recover
 \fBaptly\fR \fBserve\fR
 .
 .P
-Command serve starts embedded HTTP server (not suitable for real production usage) to serve contents of public/ subdirectory of aptly\(cqs root that contains published repositories\.
+Command serve starts embedded HTTP server (not suitable for real production usage) to serve contents of public/ subdirectory of aptly\'s root that contains published repositories\.
 .
 .P
 Example:
@@ -1512,7 +1521,7 @@ Example:
 .P
 $ aptly graph
 .
-.SH "SHOW CURRENT APTLY\(cqS CONFIG"
+.SH "SHOW CURRENT APTLY\'S CONFIG"
 \fBaptly\fR \fBconfig\fR \fBshow\fR
 .
 .P
@@ -1525,7 +1534,7 @@ Example:
 $ aptly config show
 .
 .SH "RUN APTLY TASKS"
-\fBaptly\fR \fBtask\fR \fBrun\fR \-filename=\fIfilename\fR \fB|\fR \fIcommand1\fR, \fIcommand2\fR, \fB\|\.\|\.\|\.\fR
+\fBaptly\fR \fBtask\fR \fBrun\fR \-filename=\fIfilename\fR \fB|\fR \fIcommand1\fR, \fIcommand2\fR, \fB\.\.\.\fR
 .
 .P
 Command helps organise multiple aptly commands in one single aptly task, running as single thread\.

--- a/man/aptly.1.ronn.tmpl
+++ b/man/aptly.1.ronn.tmpl
@@ -43,6 +43,7 @@ Configuration file is stored in JSON format (default values shown below):
       "S3PublishEndpoints": {
         "test": {
           "region": "us-east-1",
+          "s3endpoint": "",
           "bucket": "repo",
           "awsAccessKeyID": "",
           "awsSecretAccessKey": "",
@@ -124,6 +125,8 @@ and associated settings:
 
    * `region`:
      Amazon region for S3 bucket (e.g. `us-east-1`)
+   * `s3endpoint`:
+     Custom S3 Endpoint url for non-Amazon S3, leave empty to use Amazon.
    * `bucket`:
      bucket name
    * `prefix`:

--- a/s3/public.go
+++ b/s3/public.go
@@ -149,7 +149,7 @@ func (storage *PublishedStorage) Remove(path string) error {
 
 // RemoveDirs removes directory structure under public path
 func (storage *PublishedStorage) RemoveDirs(path string, progress aptly.Progress) error {
-	const page = 1000
+	const page = 1
 
 	filelist, err := storage.Filelist(path)
 	if err != nil {
@@ -171,7 +171,7 @@ func (storage *PublishedStorage) RemoveDirs(path string, progress aptly.Progress
 			paths[i] = filepath.Join(storage.prefix, path, part[i])
 		}
 
-		err = storage.bucket.MultiDel(paths)
+		err = storage.bucket.Del(paths[0])
 		if err != nil {
 			return fmt.Errorf("error deleting multiple paths from %s: %s", storage, err)
 		}

--- a/s3/public_test.go
+++ b/s3/public_test.go
@@ -40,9 +40,13 @@ func (s *PublishedStorageSuite) TearDownTest(c *C) {
 }
 
 func (s *PublishedStorageSuite) TestNewPublishedStorage(c *C) {
-	stor, err := NewPublishedStorage("aa", "bbb", "", "", "", "", "", "", false)
+	stor, err := NewPublishedStorage("aa", "bbb", "ccc", "", "", "", "", "", "", false)
 	c.Check(stor, IsNil)
-	c.Check(err, ErrorMatches, "unknown region: .*")
+	c.Check(err, ErrorMatches, "unknown Amazon region: .*")
+
+	stor2, err2 := NewPublishedStorage("aa", "bbb", "ccc", "ddd", "", "", "", "", "", false)
+	c.Check(stor2, NotNil)
+	c.Check(err2, IsNil)
 }
 
 func (s *PublishedStorageSuite) TestPutFile(c *C) {

--- a/utils/config.go
+++ b/utils/config.go
@@ -28,6 +28,7 @@ type ConfigStructure struct {
 // S3PublishRoot describes single S3 publishing entry point
 type S3PublishRoot struct {
 	Region           string `json:"region"`
+	S3endpoint       string `json:"s3endpoint"`
 	Bucket           string `json:"bucket"`
 	AccessKeyID      string `json:"awsAccessKeyID"`
 	SecretAccessKey  string `json:"awsSecretAccessKey"`

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -65,6 +65,7 @@ func (s *ConfigSuite) TestSaveConfig(c *C) {
 		"  \"S3PublishEndpoints\": {\n"+
 		"    \"test\": {\n"+
 		"      \"region\": \"us-east-1\",\n"+
+		"      \"s3endpoint\": \"\",\n"+
 		"      \"bucket\": \"repo\",\n"+
 		"      \"awsAccessKeyID\": \"\",\n"+
 		"      \"awsSecretAccessKey\": \"\",\n"+


### PR DESCRIPTION
This PR is meant for review only. `make test` is passing, I think I updated everything that was expected.

FYI

At this point I only extended the config with the S3endpoint parameter from aws.Region
This keeps by default `S3LowercaseBucket` to true, while I tested a bucket name with some upper case letters, which works on this backend. Perhaps this feature would benefit from looking at more parameters? Or in a future patch...

Now on the patch itself.

Tested it with http://auroraobjects.eu/ (S3 on top of Ceph backend) shows publishing repo's work as expected.

However dropping a published repo, yields errors, strangely a different one depending of using tls or not.

Without tls (plain http):
```
$ aptly publish drop squeeze s3:aptly:aptly
ERROR: unable to remove: error deleting multiple paths from S3: auroradam:aptly/: 411 Length Required
```
With https:
```
$ aptly publish drop squeeze s3:aptly:aptly
ERROR: unable to remove: error deleting multiple paths from S3: auroradam:aptly/: Request Content-Type is not multipart/form-data
```

At this point, I'm not sure where to look.