### PR TITLE
Remove empty Depends from published metadata

### DIFF
--- a/deb/publish.go
+++ b/deb/publish.go
@@ -555,7 +555,14 @@ func (p *PublishedRepo) Publish(packagePool aptly.PackagePool, publishedStorageP
 						return err
 					}
 
-					err = pkg.Stanza().WriteTo(bufWriter, pkg.IsSource, false)
+					stanza := pkg.Stanza()
+
+					value, ok := stanza["Depends"]
+					if ok && strings.TrimSpace(value) == "" {
+						delete(stanza, "Depends")
+					}
+
+					err = stanza.WriteTo(bufWriter, pkg.IsSource, false)
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
This fix for #233 works in theory, however, is this the right place to do this? and is this the right thing to do? - I'll look at tests depending on the answer to these questions.