### PR TITLE
fix some packages not being included, because of badly parsed folded field

### DIFF
--- a/deb/format.go
+++ b/deb/format.go
@@ -230,7 +230,9 @@ func (c *ControlFileReader) ReadStanza(isRelease bool) (Stanza, error) {
 			if lastFieldMultiline {
 				stanza[lastField] += line + "\n"
 			} else {
-				stanza[lastField] += strings.TrimSpace(line)
+				//if we trim the line, folded field case gets interpreted badly during string.Fields(stanza[...])
+				// Binary is an example of such field
+				stanza[lastField] += line
 			}
 		} else {
 			parts := strings.SplitN(line, ":", 2)


### PR DESCRIPTION
according to https://www.debian.org/doc/debian-policy/ch-controlfields.html
Binary filed is a folded type.

During building boost genchanges folds Binary to multiple lines. (it has many binary packages from one source)
When aptly trims whitespace it then contatenates package names at the end of the line and beginning of the next line