### PR TITLE
Add a flag to unlock database after each API request

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -32,25 +32,27 @@ func cacheFlusher() {
 	for {
 		<-ticker
 
-		// lock everything to eliminate in-progress calls
-		r := context.CollectionFactory().RemoteRepoCollection()
-		r.Lock()
-		defer r.Unlock()
+		func() {
+			// lock everything to eliminate in-progress calls
+			r := context.CollectionFactory().RemoteRepoCollection()
+			r.Lock()
+			defer r.Unlock()
 
-		l := context.CollectionFactory().LocalRepoCollection()
-		l.Lock()
-		defer l.Unlock()
+			l := context.CollectionFactory().LocalRepoCollection()
+			l.Lock()
+			defer l.Unlock()
 
-		s := context.CollectionFactory().SnapshotCollection()
-		s.Lock()
-		defer s.Unlock()
+			s := context.CollectionFactory().SnapshotCollection()
+			s.Lock()
+			defer s.Unlock()
 
-		p := context.CollectionFactory().PublishedRepoCollection()
-		p.Lock()
-		defer p.Unlock()
+			p := context.CollectionFactory().PublishedRepoCollection()
+			p.Lock()
+			defer p.Unlock()
 
-		// all collections locked, flush them
-		context.CollectionFactory().Flush()
+			// all collections locked, flush them
+			context.CollectionFactory().Flush()
+		}()
 	}
 }
 

--- a/cmd/api_serve.go
+++ b/cmd/api_serve.go
@@ -46,6 +46,7 @@ Example:
 	}
 
 	cmd.Flag.String("listen", ":8080", "host:port for HTTP listening")
+	cmd.Flag.Bool("no-lock", false, "don't lock the database")
 
 	return cmd
 

--- a/man/aptly.1
+++ b/man/aptly.1
@@ -1658,6 +1658,10 @@ Options:
 \-\fBlisten\fR=:8080
 host:port for HTTP listening
 .
+.TP
+\-\fBno-lock\fR
+don't lock the database and allow one to still use the command-line client
+.
 .SH "RENDER GRAPH OF RELATIONSHIPS"
 \fBaptly\fR \fBgraph\fR
 .


### PR DESCRIPTION
After the first API request, the database was locked as long as the API
server is running. This prevents a user to also use the command-line
client. This commit adds a new flag `-no-lock` that will close the
database after each API request.

Closes #234