### PR TITLE
Fix lock handling in cache flusher for API

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -32,25 +32,27 @@ func cacheFlusher() {
 	for {
 		<-ticker
 
-		// lock everything to eliminate in-progress calls
-		r := context.CollectionFactory().RemoteRepoCollection()
-		r.Lock()
-		defer r.Unlock()
+		func() {
+			// lock everything to eliminate in-progress calls
+			r := context.CollectionFactory().RemoteRepoCollection()
+			r.Lock()
+			defer r.Unlock()
 
-		l := context.CollectionFactory().LocalRepoCollection()
-		l.Lock()
-		defer l.Unlock()
+			l := context.CollectionFactory().LocalRepoCollection()
+			l.Lock()
+			defer l.Unlock()
 
-		s := context.CollectionFactory().SnapshotCollection()
-		s.Lock()
-		defer s.Unlock()
+			s := context.CollectionFactory().SnapshotCollection()
+			s.Lock()
+			defer s.Unlock()
 
-		p := context.CollectionFactory().PublishedRepoCollection()
-		p.Lock()
-		defer p.Unlock()
+			p := context.CollectionFactory().PublishedRepoCollection()
+			p.Lock()
+			defer p.Unlock()
 
-		// all collections locked, flush them
-		context.CollectionFactory().Flush()
+			// all collections locked, flush them
+			context.CollectionFactory().Flush()
+		}()
 	}
 }
 


### PR DESCRIPTION
Unlocking the different elements in cache flusher was deferred to the
end of the function. Unfortunately, being a for loop wrapped in a
goroutine, deferred were never executed.

I think that unlocking was still done due to garbage collection.