### PR TITLE
[SECURITY] Only download Files without checksum when checksum is ignored anyway

### DIFF
--- a/http/download.go
+++ b/http/download.go
@@ -327,7 +327,11 @@ func DownloadTryCompression(downloader aptly.Downloader, url string, expectedChe
 		}
 
 		if !foundChecksum {
-			file, err = DownloadTemp(downloader, tryURL)
+			if !ignoreMismatch {
+				continue
+			} else {
+				file, err = DownloadTemp(downloader, tryURL)
+			}
 		}
 
 		if err != nil {


### PR DESCRIPTION
Downloading and using e.g. Packege.bz2 when there is no Checksum for it
will break the trust-chain started from the Release-file.