### PR TITLE
add Checksums-Sha512 to isMultilineField

### DIFF
--- a/deb/format.go
+++ b/deb/format.go
@@ -106,6 +106,8 @@ func isMultilineField(field string, isRelease bool) bool {
 		return true
 	case "Checksums-Sha256":
 		return true
+	case "Checksums-Sha512":
+		return true
 	case "Package-List":
 		return true
 	case "MD5Sum":


### PR DESCRIPTION
Otherwise line breaks are not properly handled and the output contains
excess newlines

Fixes #361 

Unfortunately I did not manage to fully comprehend the test suite yet, so I am not able to write a test around this.