### PR TITLE
gpg: Sign with SHA-256 for compatibility with APT 1.2.7

### DIFF
--- a/utils/gpg.go
+++ b/utils/gpg.go
@@ -143,7 +143,7 @@ func (g *GpgSigner) Init() error {
 func (g *GpgSigner) DetachedSign(source string, destination string) error {
 	fmt.Printf("Signing file '%s' with gpg, please enter your passphrase when prompted:\n", filepath.Base(source))
 
-	args := []string{"-o", destination, "--armor", "--yes"}
+	args := []string{"-o", destination, "--digest-algo", "SHA256", "--armor", "--yes"}
 	args = append(args, g.gpgArgs()...)
 	args = append(args, "--detach-sign", source)
 	cmd := exec.Command("gpg", args...)
@@ -156,7 +156,7 @@ func (g *GpgSigner) DetachedSign(source string, destination string) error {
 // ClearSign clear-signs the file
 func (g *GpgSigner) ClearSign(source string, destination string) error {
 	fmt.Printf("Clearsigning file '%s' with gpg, please enter your passphrase when prompted:\n", filepath.Base(source))
-	args := []string{"-o", destination, "--yes"}
+	args := []string{"-o", destination, "--digest-algo", "SHA256", "--yes"}
 	args = append(args, g.gpgArgs()...)
 	args = append(args, "--clearsign", source)
 	cmd := exec.Command("gpg", args...)


### PR DESCRIPTION
APT 1.2.7, which was released earlier this week and will be in Ubuntu 16.04 LTS, gives a warning on signed repositories where the GPG signature uses SHA-1 or weaker. This will be upgraded to a hard error in Ubuntu 16.10 and in some post-release update to 16.04, as well as in Debian 9. See the [developer's blog post](https://juliank.wordpress.com/2016/03/14/dropping-sha-1-support-in-apt/) and [a follow-up post](https://juliank.wordpress.com/2016/03/15/clarifications-and-updates-on-apt-sha1/) for more information.

This change forces aptly to sign Release and InRelease files with SHA-256. gpg's default signature algorithm is SHA-1, so e.g. http://repo.aptly.info/dists/squeeze/InRelease uses SHA-1. (Users will need to re-publish all existing repositories after this change.)