### PR TITLE
Fixed mkdir mode from 755 to 777

### DIFF
--- a/files/package_pool.go
+++ b/files/package_pool.go
@@ -151,7 +151,7 @@ func (pool *PackagePool) Import(path string, hashMD5 string) error {
 	}
 
 	// create subdirs as necessary
-	err = os.MkdirAll(filepath.Dir(poolPath), 0755)
+	err = os.MkdirAll(filepath.Dir(poolPath), 0777)
 	if err != nil {
 		return err
 	}

--- a/files/public.go
+++ b/files/public.go
@@ -32,7 +32,7 @@ func (storage *PublishedStorage) PublicPath() string {
 
 // MkDir creates directory recursively under public path
 func (storage *PublishedStorage) MkDir(path string) error {
-	return os.MkdirAll(filepath.Join(storage.rootPath, path), 0755)
+	return os.MkdirAll(filepath.Join(storage.rootPath, path), 0777)
 }
 
 // PutFile puts file into published storage at specified path
@@ -87,7 +87,7 @@ func (storage *PublishedStorage) LinkFromPool(publishedDirectory string, sourceP
 	baseName := filepath.Base(sourcePath)
 	poolPath := filepath.Join(storage.rootPath, publishedDirectory)
 
-	err := os.MkdirAll(poolPath, 0755)
+	err := os.MkdirAll(poolPath, 0777)
 	if err != nil {
 		return err
 	}

--- a/http/download.go
+++ b/http/download.go
@@ -167,7 +167,7 @@ func (downloader *downloaderImpl) handleTask(task *downloadTask) {
 		return
 	}
 
-	err = os.MkdirAll(filepath.Dir(task.destination), 0755)
+	err = os.MkdirAll(filepath.Dir(task.destination), 0777)
 	if err != nil {
 		task.result <- fmt.Errorf("%s: %s", task.url, err)
 		return


### PR DESCRIPTION
Directory creation isn't using the 0777 mode as advertised by the FAQ, this fixes the mode in few places (there might be other places where using 0777 is appropriate).