### PR TITLE
Added '.xz' extension in HTTP download.

### DIFF
--- a/deb/remote_test.go
+++ b/deb/remote_test.go
@@ -329,6 +329,7 @@ func (s *RemoteRepoSuite) TestDownloadFlat(c *C) {
 	downloader.ExpectResponse("http://repos.express42.com/virool/precise/Release", exampleReleaseFile)
 	downloader.ExpectError("http://repos.express42.com/virool/precise/Packages.bz2", &http.HTTPError{Code: 404})
 	downloader.ExpectError("http://repos.express42.com/virool/precise/Packages.gz", &http.HTTPError{Code: 404})
+	downloader.ExpectError("http://repos.express42.com/virool/precise/Packages.xz", &http.HTTPError{Code: 404})
 	downloader.ExpectResponse("http://repos.express42.com/virool/precise/Packages", examplePackagesFile)
 
 	err := s.flat.Fetch(downloader, nil)
@@ -359,9 +360,11 @@ func (s *RemoteRepoSuite) TestDownloadWithSourcesFlat(c *C) {
 	downloader.ExpectResponse("http://repos.express42.com/virool/precise/Release", exampleReleaseFile)
 	downloader.ExpectError("http://repos.express42.com/virool/precise/Packages.bz2", &http.HTTPError{Code: 404})
 	downloader.ExpectError("http://repos.express42.com/virool/precise/Packages.gz", &http.HTTPError{Code: 404})
+	downloader.ExpectError("http://repos.express42.com/virool/precise/Packages.xz", &http.HTTPError{Code: 404})
 	downloader.ExpectResponse("http://repos.express42.com/virool/precise/Packages", examplePackagesFile)
 	downloader.ExpectError("http://repos.express42.com/virool/precise/Sources.bz2", &http.HTTPError{Code: 404})
 	downloader.ExpectError("http://repos.express42.com/virool/precise/Sources.gz", &http.HTTPError{Code: 404})
+	downloader.ExpectError("http://repos.express42.com/virool/precise/Sources.xz", &http.HTTPError{Code: 404})
 	downloader.ExpectResponse("http://repos.express42.com/virool/precise/Sources", exampleSourcesFile)
 
 	err := s.flat.Fetch(downloader, nil)

--- a/http/download.go
+++ b/http/download.go
@@ -3,6 +3,7 @@ package http
 import (
 	"compress/bzip2"
 	"compress/gzip"
+	"github.com/smira/go-xz"
 	"fmt"
 	"github.com/mxk/go-flowrate/flowrate"
 	"github.com/smira/aptly/aptly"
@@ -302,6 +303,10 @@ var compressionMethods = []struct {
 	{
 		extenstion:     ".gz",
 		transformation: func(r io.Reader) (io.Reader, error) { return gzip.NewReader(r) },
+	},
+	{
+		extenstion:     ".xz",
+		transformation: func(r io.Reader) (io.Reader, error) { return xz.NewReader(r) },
 	},
 	{
 		extenstion:     "",

--- a/http/download_test.go
+++ b/http/download_test.go
@@ -204,6 +204,7 @@ func (s *DownloaderSuite) TestDownloadTempError(c *C) {
 const (
 	bzipData = "BZh91AY&SY\xcc\xc3q\xd4\x00\x00\x02A\x80\x00\x10\x02\x00\x0c\x00 \x00!\x9ah3M\x19\x97\x8b\xb9\"\x9c(Hfa\xb8\xea\x00"
 	gzipData = "\x1f\x8b\x08\x00\xc8j\xb0R\x00\x03+I-.\xe1\x02\x00\xc65\xb9;\x05\x00\x00\x00"
+	xzData   = "\xfd\x37\x7a\x58\x5a\x00\x00\x04\xe6\xd6\xb4\x46\x02\x00\x21\x01\x16\x00\x00\x00\x74\x2f\xe5\xa3\x01\x00\x04\x74\x65\x73\x74\x0a\x00\x00\x00\x00\x9d\xed\x31\x1d\x0f\x9f\xd7\xe6\x00\x01\x1d\x05\xb8\x2d\x80\xaf\x1f\xb6\xf3\x7d\x01\x00\x00\x00\x00\x04\x59\x5a"
 	rawData  = "test"
 )
 
@@ -213,6 +214,7 @@ func (s *DownloaderSuite) TestDownloadTryCompression(c *C) {
 	expectedChecksums := map[string]utils.ChecksumInfo{
 		"file.bz2": {Size: int64(len(bzipData))},
 		"file.gz":  {Size: int64(len(gzipData))},
+		"file.xz":  {Size: int64(len(xzData))},
 		"file":     {Size: int64(len(rawData))},
 	}
 
@@ -239,11 +241,25 @@ func (s *DownloaderSuite) TestDownloadTryCompression(c *C) {
 	c.Assert(string(buf), Equals, rawData)
 	c.Assert(d.Empty(), Equals, true)
 
-	// bzip2 & gzip not available, but raw is
+	// bzip2 & gzip not available, but xz is
 	buf = make([]byte, 4)
 	d = NewFakeDownloader()
 	d.ExpectError("http://example.com/file.bz2", &HTTPError{Code: 404})
 	d.ExpectError("http://example.com/file.gz", &HTTPError{Code: 404})
+	d.ExpectResponse("http://example.com/file.xz", xzData)
+	r, file, err = DownloadTryCompression(d, "http://example.com/file", expectedChecksums, false)
+	c.Assert(err, IsNil)
+	defer file.Close()
+	io.ReadFull(r, buf)
+	c.Assert(string(buf), Equals, rawData)
+	c.Assert(d.Empty(), Equals, true)
+
+	// bzip2, gzip & xz not available, but raw is
+	buf = make([]byte, 4)
+	d = NewFakeDownloader()
+	d.ExpectError("http://example.com/file.bz2", &HTTPError{Code: 404})
+	d.ExpectError("http://example.com/file.gz", &HTTPError{Code: 404})
+	d.ExpectError("http://example.com/file.xz", &HTTPError{Code: 404})
 	d.ExpectResponse("http://example.com/file", rawData)
 	r, file, err = DownloadTryCompression(d, "http://example.com/file", expectedChecksums, false)
 	c.Assert(err, IsNil)
@@ -270,6 +286,7 @@ func (s *DownloaderSuite) TestDownloadTryCompressionErrors(c *C) {
 	d = NewFakeDownloader()
 	d.ExpectError("http://example.com/file.bz2", &HTTPError{Code: 404})
 	d.ExpectError("http://example.com/file.gz", &HTTPError{Code: 404})
+	d.ExpectError("http://example.com/file.xz", &HTTPError{Code: 404})
 	d.ExpectError("http://example.com/file", errors.New("403"))
 	_, _, err = DownloadTryCompression(d, "http://example.com/file", nil, true)
 	c.Assert(err, ErrorMatches, "403")
@@ -277,10 +294,12 @@ func (s *DownloaderSuite) TestDownloadTryCompressionErrors(c *C) {
 	d = NewFakeDownloader()
 	d.ExpectError("http://example.com/file.bz2", &HTTPError{Code: 404})
 	d.ExpectError("http://example.com/file.gz", &HTTPError{Code: 404})
+	d.ExpectError("http://example.com/file.xz", &HTTPError{Code: 404})
 	d.ExpectResponse("http://example.com/file", rawData)
 	expectedChecksums := map[string]utils.ChecksumInfo{
 		"file.bz2": {Size: 7},
 		"file.gz":  {Size: 7},
+		"file.xz":  {Size: 7},
 		"file":     {Size: 7},
 	}
 	_, _, err = DownloadTryCompression(d, "http://example.com/file", expectedChecksums, false)


### PR DESCRIPTION
Hi @smira ,

I recently tried to mirror _debian/experimental_ through _aptly_. However, I was not able to do it because the only `Packages` file available in _main/binary-< arch >_ directory is `Packages.xz`.
Example: [ftp.debian.org(..)experimental/main/binary-i386/](http://ftp.debian.org/debian/dists/experimental/main/binary-i386/).

This extension (`.xz`) is not catched in `download.go`. So I reused your `github.com/smira/go-xz` to do it.

Have a good day,
