### PR TITLE
Allow overriding architecture info from Release file

### DIFF
--- a/cmd/mirror_create.go
+++ b/cmd/mirror_create.go
@@ -43,6 +43,7 @@ func aptlyMirrorCreate(cmd *commander.Command, args []string) error {
 	repo.Filter = context.Flags().Lookup("filter").Value.String()
 	repo.FilterWithDeps = context.Flags().Lookup("filter-with-deps").Value.Get().(bool)
 	repo.SkipComponentCheck = context.Flags().Lookup("force-components").Value.Get().(bool)
+	repo.SkipArchitectureCheck = context.Flags().Lookup("force-architectures").Value.Get().(bool)
 
 	if repo.Filter != "" {
 		_, err = query.Parse(repo.Filter)
@@ -97,6 +98,7 @@ Example:
 	cmd.Flag.String("filter", "", "filter packages in mirror")
 	cmd.Flag.Bool("filter-with-deps", false, "when filtering, include dependencies of matching packages as well")
 	cmd.Flag.Bool("force-components", false, "(only with component list) skip check that requested components are listed in Release file")
+	cmd.Flag.Bool("force-architectures", false, "(only with architecture list) skip check that requested architectures are listed in Release file")
 	cmd.Flag.Var(&keyRingsFlag{}, "keyring", "gpg keyring to use when verifying Release file (could be specified multiple times)")
 
 	return cmd

--- a/deb/remote.go
+++ b/deb/remote.go
@@ -60,6 +60,8 @@ type RemoteRepo struct {
 	FilterWithDeps bool
 	// SkipComponentCheck skips component list verification
 	SkipComponentCheck bool
+	// SkipArchitectureCheck skips architecture list verification
+	SkipArchitectureCheck bool
 	// Status marks state of repository (being updated, no action)
 	Status int
 	// WorkerPID is PID of the process modifying the mirror (if any)
@@ -316,9 +318,9 @@ ok:
 		architectures = utils.StrSlicesSubstract(architectures, []string{"source"})
 		if len(repo.Architectures) == 0 {
 			repo.Architectures = architectures
-		} else {
+		} else if !repo.SkipArchitectureCheck {
 			err = utils.StringsIsSubset(repo.Architectures, architectures,
-				fmt.Sprintf("architecture %%s not available in repo %s", repo))
+				fmt.Sprintf("architecture %%s not available in repo %s, use -force-architectures to override", repo))
 			if err != nil {
 				return err
 			}

--- a/system/t03_help/MirrorCreateHelpTest_gold
+++ b/system/t03_help/MirrorCreateHelpTest_gold
@@ -21,6 +21,7 @@ Options:
   -dep-follow-suggests=false: when processing dependencies, follow Suggests
   -filter="": filter packages in mirror
   -filter-with-deps=false: when filtering, include dependencies of matching packages as well
+  -force-architectures=false: (only with architecture list) skip check that requested architectures are listed in Release file
   -force-components=false: (only with component list) skip check that requested components are listed in Release file
   -ignore-signatures=false: disable verification of Release file signatures
   -keyring=: gpg keyring to use when verifying Release file (could be specified multiple times)

--- a/system/t03_help/MirrorCreateTest_gold
+++ b/system/t03_help/MirrorCreateTest_gold
@@ -12,6 +12,7 @@ Options:
   -dep-follow-suggests=false: when processing dependencies, follow Suggests
   -filter="": filter packages in mirror
   -filter-with-deps=false: when filtering, include dependencies of matching packages as well
+  -force-architectures=false: (only with architecture list) skip check that requested architectures are listed in Release file
   -force-components=false: (only with component list) skip check that requested components are listed in Release file
   -ignore-signatures=false: disable verification of Release file signatures
   -keyring=: gpg keyring to use when verifying Release file (could be specified multiple times)

--- a/system/t03_help/WrongFlagTest_gold
+++ b/system/t03_help/WrongFlagTest_gold
@@ -13,6 +13,7 @@ Options:
   -dep-follow-suggests=false: when processing dependencies, follow Suggests
   -filter="": filter packages in mirror
   -filter-with-deps=false: when filtering, include dependencies of matching packages as well
+  -force-architectures=false: (only with architecture list) skip check that requested architectures are listed in Release file
   -force-components=false: (only with component list) skip check that requested components are listed in Release file
   -ignore-signatures=false: disable verification of Release file signatures
   -keyring=: gpg keyring to use when verifying Release file (could be specified multiple times)

--- a/system/t04_mirror/CreateMirror16Test_gold
+++ b/system/t04_mirror/CreateMirror16Test_gold
@@ -1,2 +1,2 @@
 Downloading http://mirror.yandex.ru/debian/dists/wheezy/Release...
-ERROR: unable to fetch mirror: architecture source not available in repo [mirror16]: http://mirror.yandex.ru/debian/ wheezy
+ERROR: unable to fetch mirror: architecture source not available in repo [mirror16]: http://mirror.yandex.ru/debian/ wheezy, use -force-architectures to override

--- a/system/t04_mirror/CreateMirror5Test_gold
+++ b/system/t04_mirror/CreateMirror5Test_gold
@@ -1,2 +1,2 @@
 Downloading http://mirror.yandex.ru/debian/dists/wheezy/Release...
-ERROR: unable to fetch mirror: architecture nano68 not available in repo [mirror5]: http://mirror.yandex.ru/debian/ wheezy
+ERROR: unable to fetch mirror: architecture nano68 not available in repo [mirror5]: http://mirror.yandex.ru/debian/ wheezy, use -force-architectures to override


### PR DESCRIPTION
Adds a flag -force-architectures to ignore missing architectures from
mirrors. This flag can be used in cases where the mirrored repository
does not provide an "Architecture: " line.

Example Release file:
http://mitaka-jessie.pkgs.mirantis.com/debian/dists/jessie-mitaka-backports/Release