### PR TITLE
update unit tests

### DIFF
--- a/system/t04_mirror/CreateMirror11Test_mirror_show
+++ b/system/t04_mirror/CreateMirror11Test_mirror_show
@@ -11,10 +11,10 @@ Information from release file:
 Architectures: amd64 armel armhf i386 ia64 kfreebsd-amd64 kfreebsd-i386 mips mipsel powerpc s390 s390x sparc
 Codename: wheezy
 Components: main contrib non-free
-Date: Sat, 02 Apr 2016 12:02:38 UTC
-Description:  Debian 7.10 Released 02 April 2016
+Date: Sat, 04 Jun 2016 11:47:54 UTC
+Description:  Debian 7.11 Released 04 June 2016
 
 Label: Debian
 Origin: Debian
 Suite: oldstable
-Version: 7.10
+Version: 7.11

--- a/system/t04_mirror/CreateMirror13Test_mirror_show
+++ b/system/t04_mirror/CreateMirror13Test_mirror_show
@@ -11,10 +11,10 @@ Information from release file:
 Architectures: amd64 armel armhf i386 ia64 kfreebsd-amd64 kfreebsd-i386 mips mipsel powerpc s390 s390x sparc
 Codename: wheezy
 Components: main contrib non-free
-Date: Sat, 02 Apr 2016 12:02:38 UTC
-Description:  Debian 7.10 Released 02 April 2016
+Date: Sat, 04 Jun 2016 11:47:54 UTC
+Description:  Debian 7.11 Released 04 June 2016
 
 Label: Debian
 Origin: Debian
 Suite: oldstable
-Version: 7.10
+Version: 7.11

--- a/system/t04_mirror/CreateMirror17Test_mirror_show
+++ b/system/t04_mirror/CreateMirror17Test_mirror_show
@@ -11,10 +11,10 @@ Information from release file:
 Architectures: amd64 armel armhf i386 ia64 kfreebsd-amd64 kfreebsd-i386 mips mipsel powerpc s390 s390x sparc
 Codename: wheezy
 Components: main contrib non-free
-Date: Sat, 02 Apr 2016 12:02:38 UTC
-Description:  Debian 7.10 Released 02 April 2016
+Date: Sat, 04 Jun 2016 11:47:54 UTC
+Description:  Debian 7.11 Released 04 June 2016
 
 Label: Debian
 Origin: Debian
 Suite: oldstable
-Version: 7.10
+Version: 7.11

--- a/system/t04_mirror/CreateMirror1Test_mirror_show
+++ b/system/t04_mirror/CreateMirror1Test_mirror_show
@@ -11,10 +11,10 @@ Information from release file:
 Architectures: amd64 armel armhf i386 ia64 kfreebsd-amd64 kfreebsd-i386 mips mipsel powerpc s390 s390x sparc
 Codename: wheezy
 Components: main contrib non-free
-Date: Sat, 02 Apr 2016 12:02:38 UTC
-Description:  Debian 7.10 Released 02 April 2016
+Date: Sat, 04 Jun 2016 11:47:54 UTC
+Description:  Debian 7.11 Released 04 June 2016
 
 Label: Debian
 Origin: Debian
 Suite: oldstable
-Version: 7.10
+Version: 7.11

--- a/system/t04_mirror/CreateMirror21Test_mirror_show
+++ b/system/t04_mirror/CreateMirror21Test_mirror_show
@@ -10,5 +10,5 @@ Last update: never
 Information from release file:
 Architectures: all
 Date: Wed, 28 Jan 2015 02:32:16 UTC
-Origin: jenkins-ci.org
+Origin: jenkins.io
 Suite: binary

--- a/system/t04_mirror/CreateMirror25Test_mirror_show
+++ b/system/t04_mirror/CreateMirror25Test_mirror_show
@@ -11,10 +11,10 @@ Information from release file:
 Architectures: amd64 armel armhf i386 ia64 kfreebsd-amd64 kfreebsd-i386 mips mipsel powerpc s390 s390x sparc
 Codename: wheezy
 Components: main contrib non-free
-Date: Sat, 02 Apr 2016 12:02:38 UTC
-Description:  Debian 7.10 Released 02 April 2016
+Date: Sat, 04 Jun 2016 11:47:54 UTC
+Description:  Debian 7.11 Released 04 June 2016
 
 Label: Debian
 Origin: Debian
 Suite: oldstable
-Version: 7.10
+Version: 7.11

--- a/system/t04_mirror/CreateMirror2Test_mirror_show
+++ b/system/t04_mirror/CreateMirror2Test_mirror_show
@@ -11,10 +11,10 @@ Information from release file:
 Architectures: amd64 armel armhf i386 ia64 kfreebsd-amd64 kfreebsd-i386 mips mipsel powerpc s390 s390x sparc
 Codename: wheezy
 Components: main contrib non-free
-Date: Sat, 02 Apr 2016 12:02:38 UTC
-Description:  Debian 7.10 Released 02 April 2016
+Date: Sat, 04 Jun 2016 11:47:54 UTC
+Description:  Debian 7.11 Released 04 June 2016
 
 Label: Debian
 Origin: Debian
 Suite: oldstable
-Version: 7.10
+Version: 7.11

--- a/system/t04_mirror/CreateMirror3Test_mirror_show
+++ b/system/t04_mirror/CreateMirror3Test_mirror_show
@@ -11,10 +11,10 @@ Information from release file:
 Architectures: amd64 armel armhf i386 ia64 kfreebsd-amd64 kfreebsd-i386 mips mipsel powerpc s390 s390x sparc
 Codename: wheezy
 Components: main contrib non-free
-Date: Sat, 02 Apr 2016 12:02:38 UTC
-Description:  Debian 7.10 Released 02 April 2016
+Date: Sat, 04 Jun 2016 11:47:54 UTC
+Description:  Debian 7.11 Released 04 June 2016
 
 Label: Debian
 Origin: Debian
 Suite: oldstable
-Version: 7.10
+Version: 7.11

--- a/system/t04_mirror/CreateMirror7Test_mirror_show
+++ b/system/t04_mirror/CreateMirror7Test_mirror_show
@@ -11,10 +11,10 @@ Information from release file:
 Architectures: amd64 armel armhf i386 ia64 kfreebsd-amd64 kfreebsd-i386 mips mipsel powerpc s390 s390x sparc
 Codename: wheezy
 Components: main contrib non-free
-Date: Sat, 02 Apr 2016 12:02:38 UTC
-Description:  Debian 7.10 Released 02 April 2016
+Date: Sat, 04 Jun 2016 11:47:54 UTC
+Description:  Debian 7.11 Released 04 June 2016
 
 Label: Debian
 Origin: Debian
 Suite: oldstable
-Version: 7.10
+Version: 7.11

--- a/system/t04_mirror/EditMirror6Test_mirror_show
+++ b/system/t04_mirror/EditMirror6Test_mirror_show
@@ -11,10 +11,10 @@ Information from release file:
 Architectures: amd64 armel armhf i386 ia64 kfreebsd-amd64 kfreebsd-i386 mips mipsel powerpc s390 s390x sparc
 Codename: wheezy
 Components: main contrib non-free
-Date: Sat, 02 Apr 2016 12:02:38 UTC
-Description:  Debian 7.10 Released 02 April 2016
+Date: Sat, 04 Jun 2016 11:47:54 UTC
+Description:  Debian 7.11 Released 04 June 2016
 
 Label: Debian
 Origin: Debian
 Suite: oldstable
-Version: 7.10
+Version: 7.11

--- a/system/t04_mirror/ShowMirror1Test_gold
+++ b/system/t04_mirror/ShowMirror1Test_gold
@@ -11,10 +11,10 @@ Information from release file:
 Architectures: amd64 armel armhf i386 ia64 kfreebsd-amd64 kfreebsd-i386 mips mipsel powerpc s390 s390x sparc
 Codename: wheezy
 Components: main contrib non-free
-Date: Sat, 02 Apr 2016 12:02:38 UTC
-Description:  Debian 7.10 Released 02 April 2016
+Date: Sat, 04 Jun 2016 11:47:54 UTC
+Description:  Debian 7.11 Released 04 June 2016
 
 Label: Debian
 Origin: Debian
 Suite: oldstable
-Version: 7.10
+Version: 7.11

--- a/system/t07_serve/__init__.py
+++ b/system/t07_serve/__init__.py
@@ -47,7 +47,7 @@ class Serve1Test(BaseTest):
                 proc.send_signal(signal.SIGINT)
                 proc.wait()
 
-            if proc.returncode != -2:
+            if proc.returncode != -2 and proc.returncode != 2:
                 raise Exception("exit code %d != %d (output: %s)" % (proc.returncode, -2, output))
             self.output = output
         except Exception, e:

--- a/system/t07_serve/__init__.py
+++ b/system/t07_serve/__init__.py
@@ -47,8 +47,8 @@ class Serve1Test(BaseTest):
                 proc.send_signal(signal.SIGINT)
                 proc.wait()
 
-            if proc.returncode != 2:
-                raise Exception("exit code %d != %d (output: %s)" % (proc.returncode, 2, output))
+            if proc.returncode != -2:
+                raise Exception("exit code %d != %d (output: %s)" % (proc.returncode, -2, output))
             self.output = output
         except Exception, e:
             raise Exception("Running command %s failed: %s" % (self.runCmd, str(e)))


### PR DESCRIPTION
- I updated the data in the mirror files so unit tests pass
- Updated api serve exit code in tests to `-2`. As far as I know aptly is still working as intended so I'm not sure if this was changed upstream or if the unit test is actually failing. Let me know if this is incorrect.