### PR TITLE
add basic appstream support

### DIFF
--- a/Gomfile
+++ b/Gomfile
@@ -22,6 +22,7 @@ gom 'github.com/smira/lzma', :commit => '7f0af6269940baa2c938fabe73e0d7ba4120568
 gom 'github.com/golang/snappy', :commit => '723cc1e459b8eea2dea4583200fd60757d40097a'
 gom 'github.com/syndtr/goleveldb/leveldb', :commit => '917f41c560270110ceb73c5b38be2a9127387071'
 gom 'github.com/ugorji/go/codec', :commit => '71c2886f5a673a35f909803f38ece5810165097b'
+gom 'github.com/ulikunitz/xz', :commit => 'f852725cf3ed4e7dca9bd458fe881ff02b27eae4'
 gom 'github.com/vaughan0/go-ini', :commit => 'a98ad7ee00ec53921f08832bc06ecf7fd600e6a1'
 gom 'github.com/wsxiaoys/terminal/color', :commit => '5668e431776a7957528361f90ce828266c69ed08'
 gom 'golang.org/x/crypto/ssh/terminal', :commit => 'a7ead6ddf06233883deca151dffaef2effbf498f'

--- a/deb/index_files.go
+++ b/deb/index_files.go
@@ -267,7 +267,7 @@ func (files *indexFiles) AppStreamIndex(component, name string) *indexFile {
 	key := fmt.Sprintf("ai-%s-%s", component, name)
 	file, ok := files.indexes[key]
 	if !ok {
-		relativePath := filepath.Join(component, "appstream", name)
+		relativePath := filepath.Join(component, "dep11", name)
 		ext := filepath.Ext(name)
 
 		xz := false

--- a/system/t02_config/ConfigShowTest_gold
+++ b/system/t02_config/ConfigShowTest_gold
@@ -13,6 +13,7 @@
     "ppaDistributorID": "ubuntu",
     "ppaCodename": "",
     "skipContentsPublishing": false,
+    "appStreamDir": "",
     "S3PublishEndpoints": {},
     "SwiftPublishEndpoints": {}
 }

--- a/system/t02_config/CreateConfigTest_gold
+++ b/system/t02_config/CreateConfigTest_gold
@@ -13,6 +13,7 @@
   "ppaDistributorID": "ubuntu",
   "ppaCodename": "",
   "skipContentsPublishing": false,
+  "appStreamDir": "",
   "S3PublishEndpoints": {},
   "SwiftPublishEndpoints": {}
 }

--- a/utils/compress.go
+++ b/utils/compress.go
@@ -2,16 +2,18 @@ package utils
 
 import (
 	"compress/gzip"
+	"github.com/ulikunitz/xz"
 	"io"
 	"os"
 	"os/exec"
 )
 
-// CompressFile compresses file specified by source to .gz & .bz2
+// CompressFile compresses file specified by source to .gz, .xz, and .bz2
 //
-// It uses internal gzip and external bzip2, see:
+// It uses internal gzip, external xz, and external bzip2, see:
 // https://code.google.com/p/go/issues/detail?id=4828
 func CompressFile(source *os.File) error {
+	// gz compression
 	gzPath := source.Name() + ".gz"
 	gzFile, err := os.Create(gzPath)
 	if err != nil {
@@ -28,6 +30,24 @@ func CompressFile(source *os.File) error {
 		return err
 	}
 
+	// xz compression
+	xzPath := source.Name() + ".xz"
+	xzFile, err := os.Create(xzPath)
+	if err != nil {
+		return err
+	}
+	defer xzFile.Close()
+
+	xzWriter := xz.NewWriter(xzFile)
+	defer xzWriter.Close()
+
+	source.Seek(0, 0)
+	_, err = io.Copy(xzWriter, source)
+	if err != nil {
+		return err
+	}
+
+	// bzip compression
 	cmd := exec.Command("bzip2", "-k", "-f", source.Name())
 	return cmd.Run()
 }

--- a/utils/compress_test.go
+++ b/utils/compress_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"compress/bzip2"
 	"compress/gzip"
+	"github.com/ulikunitz/xz"
 	"io/ioutil"
 	"os"
 
@@ -41,7 +42,20 @@ func (s *CompressSuite) TestCompress(c *C) {
 	_, err = gzReader.Read(buf)
 	c.Assert(err, IsNil)
 
+	file.Close()
 	gzReader.Close()
+
+	c.Check(string(buf), Equals, testString)
+
+	file, err = os.Open(s.tempfile.Name() + ".xz")
+	c.Assert(err, IsNil)
+
+	xzReader, err := xz.NewReader(file)
+	c.Assert(err, IsNil)
+
+	_, err = xzReader.Read(buf)
+	c.Assert(err, IsNil)
+
 	file.Close()
 
 	c.Check(string(buf), Equals, testString)

--- a/utils/config.go
+++ b/utils/config.go
@@ -22,6 +22,7 @@ type ConfigStructure struct {
 	PpaDistributorID       string                      `json:"ppaDistributorID"`
 	PpaCodename            string                      `json:"ppaCodename"`
 	SkipContentsPublishing bool                        `json:"skipContentsPublishing"`
+	AppStreamDir           string                      `json:"appStreamDir"`
 	S3PublishRoots         map[string]S3PublishRoot    `json:"S3PublishEndpoints"`
 	SwiftPublishRoots      map[string]SwiftPublishRoot `json:"SwiftPublishEndpoints"`
 }
@@ -70,6 +71,7 @@ var Config = ConfigStructure{
 	DownloadSourcePackages: false,
 	PpaDistributorID:       "ubuntu",
 	PpaCodename:            "",
+	AppStreamDir:           "",
 	S3PublishRoots:         map[string]S3PublishRoot{},
 	SwiftPublishRoots:      map[string]SwiftPublishRoot{},
 }

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -63,6 +63,7 @@ func (s *ConfigSuite) TestSaveConfig(c *C) {
 		"  \"ppaDistributorID\": \"\",\n"+
 		"  \"ppaCodename\": \"\",\n"+
 		"  \"skipContentsPublishing\": false,\n"+
+		"  \"appStreamDir\": \"\",\n"+
 		"  \"S3PublishEndpoints\": {\n"+
 		"    \"test\": {\n"+
 		"      \"region\": \"us-east-1\",\n"+


### PR DESCRIPTION
So this is a basic implementation for appstream support #384
This is my first golang code so please forgive any bad practices.

This expects you to have a file path similar to the setup repository with uncompressed appstream files like such: `/var/appstream/stable/dists/xenial/main/Components-amd64.yml`. You would then set the `appStreamDir` field in the aptly configuration file to `/var/appstream`. On publish aptly would then compress the files as needed, and use them in Release file.

More improvements:
- use the compressed files outputted by asgen instead of requiring the uncompressed version.
