### PR TITLE
Make Travis CI be able to run on forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,11 @@ env:
 before_install:
   - virtualenv env
   - . env/bin/activate
+  - pip install -U pip setuptools
   - pip install boto requests python-swiftclient
+  - mkdir -p $GOPATH/src/github.com/smira
+  - ln -s $TRAVIS_BUILD_DIR $GOPATH/src/github.com/smira || true
+  - cd $GOPATH/src/github.com/smira/aptly
 install:
   - make prepare
 


### PR DESCRIPTION
When developing a feature it often happens during development that I do not want to create a pull request straight away but do some testing in my fork and when successful I will create a PR.

Unfortunately currently travis doesn't run on a fork due to invalid paths. This PR fixes this so a Fork can run the test unit as well.