### PR TITLE
Add systemd service for aptly http server

### DIFF
--- a/aptly-api.service
+++ b/aptly-api.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=APT repository API
+After=network.target
+Documentation=man:aptly(1)
+Documentation=https://www.aptly.info/doc/api/
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/aptly serve api -no-lock -listen=127.0.0.1:8081
+
+[Install]
+WantedBy=multi-user.target

--- a/aptly.service
+++ b/aptly.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=APT repository server
+After=network.target
+Documentation=man:aptly(1)
+Documentation=https://www.aptly.info/doc/commands/
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/aptly serve -listen=127.0.0.1:8080
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Provides a systemd service file for `aptly serve` command.
This file can be placed in `/etc/systemd/system/` (for users/administrators) or `/lib/systemd/system/` (for distributions).
Extra configuration options should be specified in a `.conf` inside `/etc/systemd/systemd/aptly.service.d/`