### PR TITLE
Allow comment and defaults to be empty when editing a repo through the API

### DIFF
--- a/api/repos.go
+++ b/api/repos.go
@@ -60,9 +60,9 @@ func apiReposCreate(c *gin.Context) {
 // PUT /api/repos/:name
 func apiReposEdit(c *gin.Context) {
 	var b struct {
-		Comment             string
-		DefaultDistribution string
-		DefaultComponent    string
+		Comment             *string
+		DefaultDistribution *string
+		DefaultComponent    *string
 	}
 
 	if !c.Bind(&b) {
@@ -79,9 +79,15 @@ func apiReposEdit(c *gin.Context) {
 		return
 	}
 
-	repo.Comment = b.Comment
-	repo.DefaultDistribution = b.DefaultDistribution
-	repo.DefaultComponent = b.DefaultComponent
+	if b.Comment != nil {
+		repo.Comment = *b.Comment
+	}
+	if b.DefaultDistribution != nil {
+		repo.DefaultDistribution = *b.DefaultDistribution
+	}
+	if b.DefaultComponent != nil {
+		repo.DefaultComponent = *b.DefaultComponent
+	}
 
 	err = collection.Update(repo)
 	if err != nil {

--- a/api/repos.go
+++ b/api/repos.go
@@ -79,15 +79,9 @@ func apiReposEdit(c *gin.Context) {
 		return
 	}
 
-	if b.Comment != "" {
-		repo.Comment = b.Comment
-	}
-	if b.DefaultDistribution != "" {
-		repo.DefaultDistribution = b.DefaultDistribution
-	}
-	if b.DefaultComponent != "" {
-		repo.DefaultComponent = b.DefaultComponent
-	}
+	repo.Comment = b.Comment
+	repo.DefaultDistribution = b.DefaultDistribution
+	repo.DefaultComponent = b.DefaultComponent
 
 	err = collection.Update(repo)
 	if err != nil {


### PR DESCRIPTION
As those fields are not required, it should be possible to set them to be empty.