### PR TITLE
Print sources details of snapshots and published repositories

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,3 +22,4 @@ List of contributors, in chronological order:
 * Phil Frost (https://github.com/bitglue)
 * Benoit Foucher (https://github.com/bentoi)
 * Geoffrey Thomas (https://github.com/geofft)
+* Oliver Sauder (https://github.com/sliverc)

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -37,6 +37,7 @@ func makeCmdPublish() *commander.Command {
 			makeCmdPublishSnapshot(),
 			makeCmdPublishSwitch(),
 			makeCmdPublishUpdate(),
+			makeCmdPublishShow(),
 		},
 	}
 }

--- a/cmd/publish_show.go
+++ b/cmd/publish_show.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/smira/aptly/deb"
+	"github.com/smira/commander"
+	"strings"
+)
+
+func aptlyPublishShow(cmd *commander.Command, args []string) error {
+	var err error
+	if len(args) < 1 || len(args) > 2 {
+		cmd.Usage()
+		return commander.ErrCommandError
+	}
+
+	distribution := args[0]
+	param := "."
+
+	if len(args) == 2 {
+		param = args[1]
+	}
+
+	storage, prefix := deb.ParsePrefix(param)
+
+	repo, err := context.CollectionFactory().PublishedRepoCollection().ByStoragePrefixDistribution(storage, prefix, distribution)
+	if err != nil {
+		return fmt.Errorf("unable to show: %s", err)
+	}
+
+	if repo.Storage != "" {
+		fmt.Printf("Storage: %s\n", repo.Storage)
+	}
+	fmt.Printf("Prefix: %s\n", repo.Prefix)
+	if repo.Distribution != "" {
+		fmt.Printf("Distribution: %s\n", repo.Distribution)
+	}
+	fmt.Printf("Architectures: %s\n", strings.Join(repo.Architectures, " "))
+
+	fmt.Printf("Sources:\n")
+	for component, sourceID := range repo.Sources {
+		var name string
+		if repo.SourceKind == "snapshot" {
+			source, err := context.CollectionFactory().SnapshotCollection().ByUUID(sourceID)
+			if err != nil {
+				continue
+			}
+			name = source.Name
+		} else if repo.SourceKind == "local" {
+			source, err := context.CollectionFactory().LocalRepoCollection().ByUUID(sourceID)
+			if err != nil {
+				continue
+			}
+			name = source.Name
+		}
+
+		if name != "" {
+			fmt.Printf("  %s: %s [%s]\n", component, name, repo.SourceKind)
+		}
+	}
+
+	return err
+}
+
+func makeCmdPublishShow() *commander.Command {
+	cmd := &commander.Command{
+		Run:       aptlyPublishShow,
+		UsageLine: "show <distribution> [[<endpoint>:]<prefix>]",
+		Short:     "shows details of published repository",
+		Long: `
+Command show displays full information of a published repository.
+
+Example:
+
+    $ aptly publish show wheezy
+`,
+	}
+
+	return cmd
+}

--- a/cmd/snapshot_show.go
+++ b/cmd/snapshot_show.go
@@ -29,6 +29,35 @@ func aptlySnapshotShow(cmd *commander.Command, args []string) error {
 	fmt.Printf("Created At: %s\n", snapshot.CreatedAt.Format("2006-01-02 15:04:05 MST"))
 	fmt.Printf("Description: %s\n", snapshot.Description)
 	fmt.Printf("Number of packages: %d\n", snapshot.NumPackages())
+	if len(snapshot.SourceIDs) > 0 {
+		fmt.Printf("Sources:\n")
+		for _, sourceID := range snapshot.SourceIDs {
+			var name string
+			if snapshot.SourceKind == "snapshot" {
+				source, err := context.CollectionFactory().SnapshotCollection().ByUUID(sourceID)
+				if err != nil {
+					continue
+				}
+				name = source.Name
+			} else if snapshot.SourceKind == "local" {
+				source, err := context.CollectionFactory().LocalRepoCollection().ByUUID(sourceID)
+				if err != nil {
+					continue
+				}
+				name = source.Name
+			} else if snapshot.SourceKind == "repo" {
+				source, err := context.CollectionFactory().RemoteRepoCollection().ByUUID(sourceID)
+				if err != nil {
+					continue
+				}
+				name = source.Name
+			}
+
+			if name != "" {
+				fmt.Printf("  %s [%s]\n", name, snapshot.SourceKind)
+			}
+		}
+	}
 
 	withPackages := context.Flags().Lookup("with-packages").Value.Get().(bool)
 	if withPackages {

--- a/man/aptly.1
+++ b/man/aptly.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "APTLY" "1" "2017-01-10" "" ""
+.TH "APTLY" "1" "January 2017" "" ""
 .
 .SH "NAME"
 \fBaptly\fR \- Debian repository management tool
@@ -10,7 +10,7 @@
 Common command format:
 .
 .P
-\fBaptly\fR [\fIglobal options\fR\.\.\.] \fIcommand\fR \fIsubcommand\fR [\fIoptions\fR\.\.\.] \fIarguments\fR
+\fBaptly\fR [\fIglobal options\fR\|\.\|\.\|\.] \fIcommand\fR \fIsubcommand\fR [\fIoptions\fR\|\.\|\.\|\.] \fIarguments\fR
 .
 .P
 aptly has integrated help that matches contents of this manual page, to get help, prepend \fBhelp\fR to command name:
@@ -22,7 +22,7 @@ aptly has integrated help that matches contents of this manual page, to get help
 aptly is a tool to create partial and full mirrors of remote repositories, manage local repositories, filter them, merge, upgrade individual packages, take snapshots and publish them back as Debian repositories\.
 .
 .P
-aptly\'s goal is to establish repeatability and controlled changes in a package\-centric environment\. aptly allows one to fix a set of packages in a repository, so that package installation and upgrade becomes deterministic\. At the same time aptly allows one to perform controlled, fine\-grained changes in repository contents to transition your package environment to new version\.
+aptly\(cqs goal is to establish repeatability and controlled changes in a package\-centric environment\. aptly allows one to fix a set of packages in a repository, so that package installation and upgrade becomes deterministic\. At the same time aptly allows one to perform controlled, fine\-grained changes in repository contents to transition your package environment to new version\.
 .
 .SH "CONFIGURATION"
 aptly looks for configuration file first in \fB~/\.aptly\.conf\fR then in \fB/etc/aptly\.conf\fR and, if no config file found, new one is created in home directory\. If \fB\-config=\fR flag is specified, aptly would use config file at specified location\. Also aptly needs root directory for database, package and published repository storage\. If not specified, directory defaults to \fB~/\.aptly\fR, it will be created if missing\.
@@ -120,11 +120,11 @@ follow dependency from binary package to source package
 .
 .TP
 \fBgpgDisableSign\fR
-don\'t sign published repositories with gpg(1), also can be disabled on per\-repo basis using \fB\-skip\-signing\fR flag when publishing
+don\(cqt sign published repositories with gpg(1), also can be disabled on per\-repo basis using \fB\-skip\-signing\fR flag when publishing
 .
 .TP
 \fBgpgDisableVerify\fR
-don\'t verify remote mirrors with gpg(1), also can be disabled on per\-mirror basis using \fB\-ignore\-signatures\fR flag when creating and updating mirrors
+don\(cqt verify remote mirrors with gpg(1), also can be disabled on per\-mirror basis using \fB\-ignore\-signatures\fR flag when creating and updating mirrors
 .
 .TP
 \fBdownloadSourcePackages\fR
@@ -238,22 +238,22 @@ syntax is the same as for dependency conditions, but instead of package name fie
 .P
 Supported fields:
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 all field names from Debian package control files are supported except for \fBFilename\fR, \fBMD5sum\fR, \fBSHA1\fR, \fBSHA256\fR, \fBSize\fR, \fBFiles\fR, \fBChecksums\-SHA1\fR, \fBChecksums\-SHA256\fR\.
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 \fB$Source\fR is a name of source package (for binary packages)
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 \fB$SourceVersion\fR is a version of source package
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 \fB$Architecture\fR is \fBArchitecture\fR for binary packages and \fBsource\fR for source packages, when matching with equal (\fB=\fR) operator, package with \fBany\fR architecture matches all architectures but \fBsource\fR\.
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 \fB$Version\fR has the same value as \fBVersion\fR, but comparison operators use Debian version precedence rules
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 \fB$PackageType\fR is \fBdeb\fR for binary packages and \fBsource\fR for source packages
 .
 .IP "" 0
@@ -278,7 +278,7 @@ pattern matching, like shell patterns, supported special symbols are: \fB[^]?*\f
 regular expression matching, e\.g\.: \fBName (~ \.*\-dev)\fR
 .
 .P
-Simple terms could be combined into more complex queries using operators \fB,\fR (and), \fB|\fR (or) and \fB!\fR (not), parentheses \fB()\fR are used to change operator precedence\. Match value could be enclosed in single (\fB\'\fR) or double (\fB"\fR) quotes if required to resolve ambiguity, quotes inside quoted string should escaped with slash (\fB\e\fR)\.
+Simple terms could be combined into more complex queries using operators \fB,\fR (and), \fB|\fR (or) and \fB!\fR (not), parentheses \fB()\fR are used to change operator precedence\. Match value could be enclosed in single (\fB\(cq\fR) or double (\fB"\fR) quotes if required to resolve ambiguity, quotes inside quoted string should escaped with slash (\fB\e\fR)\.
 .
 .P
 Examples:
@@ -315,10 +315,10 @@ matches all packages that provide \fBmail\-transport\fR with name that has no su
 When specified on command line, query may have to be quoted according to shell rules, so that it stays single argument:
 .
 .P
-\fBaptly repo import percona stable \'mysql\-client (>= 3\.6)\'\fR
+\fBaptly repo import percona stable \(cqmysql\-client (>= 3\.6)\(cq\fR
 .
 .SH "PACKAGE DISPLAY FORMAT"
-Some aptly commands (\fBaptly mirror search\fR, \fBaptly package search\fR, \.\.\.) support \fB\-format\fR flag which allows to customize how search results are printed\. Golang templates are used to specify display format, with all package stanza fields available to template\. In addition to package stanza fields aptly provides:
+Some aptly commands (\fBaptly mirror search\fR, \fBaptly package search\fR, \|\.\|\.\|\.) support \fB\-format\fR flag which allows to customize how search results are printed\. Golang templates are used to specify display format, with all package stanza fields available to template\. In addition to package stanza fields aptly provides:
 .
 .TP
 \fBKey\fR
@@ -330,7 +330,7 @@ hash that includes MD5 of all packages files\.
 .
 .TP
 \fBShortKey\fR
-package ID, which is unique in single list (mirror, repo, snapshot, \.\.\.), but not unique in whole aptly package collection\.
+package ID, which is unique in single list (mirror, repo, snapshot, \|\.\|\.\|\.), but not unique in whole aptly package collection\.
 .
 .P
 For example, default aptly display format could be presented with the following template: \fB{{\.Package}}_{{\.Version}}_{{\.Architecture}}\fR\. To display package name with dependencies: \fB{{\.Package}} | {{\.Depends}}\fR\. More information on Golang template syntax: http://godoc\.org/text/template
@@ -347,7 +347,7 @@ location of configuration file (default locations are /etc/aptly\.conf, ~/\.aptl
 .
 .TP
 \-\fBdep\-follow\-all\-variants\fR=false
-when processing dependencies, follow a & b if dependency is \'a|b\'
+when processing dependencies, follow a & b if dependency is \(cqa|b\(cq
 .
 .TP
 \-\fBdep\-follow\-recommends\fR=false
@@ -362,10 +362,10 @@ when processing dependencies, follow from binary to Source packages
 when processing dependencies, follow Suggests
 .
 .SH "CREATE NEW MIRROR"
-\fBaptly\fR \fBmirror\fR \fBcreate\fR \fIname\fR \fIarchive url\fR \fIdistribution\fR [\fIcomponent1\fR \.\.\.]
+\fBaptly\fR \fBmirror\fR \fBcreate\fR \fIname\fR \fIarchive url\fR \fIdistribution\fR [\fIcomponent1\fR \|\.\|\.\|\.]
 .
 .P
-Creates mirror \fIname\fR of remote repository, aptly supports both regular and flat Debian repositories exported via HTTP and FTP\. aptly would try download Release file from remote repository and verify its\' signature\. Command line format resembles apt utlitily sources\.list(5)\.
+Creates mirror \fIname\fR of remote repository, aptly supports both regular and flat Debian repositories exported via HTTP and FTP\. aptly would try download Release file from remote repository and verify its\(cq signature\. Command line format resembles apt utlitily sources\.list(5)\.
 .
 .P
 PPA urls could specified in short format:
@@ -566,7 +566,7 @@ Example:
 .
 .nf
 
-$ aptly mirror search wheezy\-main \'$Architecture (i386), Name (% *\-dev)\'
+$ aptly mirror search wheezy\-main \(cq$Architecture (i386), Name (% *\-dev)\(cq
 .
 .fi
 .
@@ -607,7 +607,7 @@ when adding package that conflicts with existing package, remove existing packag
 remove files that have been imported successfully into repository
 .
 .SH "COPY PACKAGES BETWEEN LOCAL REPOSITORIES"
-\fBaptly\fR \fBrepo\fR \fBcopy\fR \fIsrc\-name\fR \fIdst\-name\fR \fIpackage\-query\fR \fB\.\.\.\fR
+\fBaptly\fR \fBrepo\fR \fBcopy\fR \fIsrc\-name\fR \fIdst\-name\fR \fIpackage\-query\fR \fB\|\.\|\.\|\.\fR
 .
 .P
 Command copy copies packages matching \fIpackage\-query\fR from local repo \fIsrc\-name\fR to local repo \fIdst\-name\fR\.
@@ -616,14 +616,14 @@ Command copy copies packages matching \fIpackage\-query\fR from local repo \fIsr
 Example:
 .
 .P
-$ aptly repo copy testing stable \'myapp (=0\.1\.12)\'
+$ aptly repo copy testing stable \(cqmyapp (=0\.1\.12)\(cq
 .
 .P
 Options:
 .
 .TP
 \-\fBdry\-run\fR=false
-don\'t copy, just show what would be copied
+don\(cqt copy, just show what would be copied
 .
 .TP
 \-\fBwith\-deps\fR=false
@@ -711,7 +711,7 @@ default distribution when publishing
 uploaders\.json to be used when including \.changes into this repository
 .
 .SH "IMPORT PACKAGES FROM MIRROR TO LOCAL REPOSITORY"
-\fBaptly\fR \fBrepo\fR \fBimport\fR \fIsrc\-mirror\fR \fIdst\-repo\fR \fIpackage\-query\fR \fB\.\.\.\fR
+\fBaptly\fR \fBrepo\fR \fBimport\fR \fIsrc\-mirror\fR \fIdst\-repo\fR \fIpackage\-query\fR \fB\|\.\|\.\|\.\fR
 .
 .P
 Command import looks up packages matching \fIpackage\-query\fR in mirror \fIsrc\-mirror\fR and copies them to local repo \fIdst\-repo\fR\.
@@ -727,7 +727,7 @@ Options:
 .
 .TP
 \-\fBdry\-run\fR=false
-don\'t import, just show what would be imported
+don\(cqt import, just show what would be imported
 .
 .TP
 \-\fBwith\-deps\fR=false
@@ -753,7 +753,7 @@ Options:
 display list in machine\-readable format
 .
 .SH "MOVE PACKAGES BETWEEN LOCAL REPOSITORIES"
-\fBaptly\fR \fBrepo\fR \fBmove\fR \fIsrc\-name\fR \fIdst\-name\fR \fIpackage\-query\fR \fB\.\.\.\fR
+\fBaptly\fR \fBrepo\fR \fBmove\fR \fIsrc\-name\fR \fIdst\-name\fR \fIpackage\-query\fR \fB\|\.\|\.\|\.\fR
 .
 .P
 Command move moves packages matching \fIpackage\-query\fR from local repo \fIsrc\-name\fR to local repo \fIdst\-name\fR\.
@@ -762,37 +762,37 @@ Command move moves packages matching \fIpackage\-query\fR from local repo \fIsrc
 Example:
 .
 .P
-$ aptly repo move testing stable \'myapp (=0\.1\.12)\'
+$ aptly repo move testing stable \(cqmyapp (=0\.1\.12)\(cq
 .
 .P
 Options:
 .
 .TP
 \-\fBdry\-run\fR=false
-don\'t move, just show what would be moved
+don\(cqt move, just show what would be moved
 .
 .TP
 \-\fBwith\-deps\fR=false
 follow dependencies when processing package\-spec
 .
 .SH "REMOVE PACKAGES FROM LOCAL REPOSITORY"
-\fBaptly\fR \fBrepo\fR \fBremove\fR \fIname\fR \fIpackage\-query\fR \fB\.\.\.\fR
+\fBaptly\fR \fBrepo\fR \fBremove\fR \fIname\fR \fIpackage\-query\fR \fB\|\.\|\.\|\.\fR
 .
 .P
-Commands removes packages matching \fIpackage\-query\fR from local repository \fIname\fR\. If removed packages are not referenced by other repos or snapshots, they can be removed completely (including files) by running \'aptly db cleanup\'\.
+Commands removes packages matching \fIpackage\-query\fR from local repository \fIname\fR\. If removed packages are not referenced by other repos or snapshots, they can be removed completely (including files) by running \(cqaptly db cleanup\(cq\.
 .
 .P
 Example:
 .
 .P
-$ aptly repo remove testing \'myapp (=0\.1\.12)\'
+$ aptly repo remove testing \(cqmyapp (=0\.1\.12)\(cq
 .
 .P
 Options:
 .
 .TP
 \-\fBdry\-run\fR=false
-don\'t remove, just show what would be removed
+don\(cqt remove, just show what would be removed
 .
 .SH "SHOW DETAILS ABOUT LOCAL REPOSITORY"
 \fBaptly\fR \fBrepo\fR \fBshow\fR \fIname\fR
@@ -835,7 +835,7 @@ Example:
 .
 .nf
 
-$ aptly repo search my\-software \'$Architecture (i386), Name (% *\-dev)\'
+$ aptly repo search my\-software \(cq$Architecture (i386), Name (% *\-dev)\(cq
 .
 .fi
 .
@@ -853,7 +853,7 @@ custom format for result printing
 include dependencies into search results
 .
 .SH "ADD PACKAGES TO LOCAL REPOSITORIES BASED ON \.CHANGES FILES"
-\fBaptly\fR \fBrepo\fR \fBinclude\fR <file\.changes>|\fIdirectory\fR \fB\.\.\.\fR
+\fBaptly\fR \fBrepo\fR \fBinclude\fR <file\.changes>|\fIdirectory\fR \fB\|\.\|\.\|\.\fR
 .
 .P
 Command include looks for \.changes files in list of arguments or specified directories\. Each \.changes file is verified, parsed, referenced files are put into separate temporary directory and added into local repository\. Successfully imported files are removed by default\.
@@ -888,7 +888,7 @@ gpg keyring to use when verifying Release file (could be specified multiple time
 .
 .TP
 \-\fBno\-remove\-files\fR=false
-don\'t remove files that have been imported successfully into repository
+don\(cqt remove files that have been imported successfully into repository
 .
 .TP
 \-\fBrepo\fR={{\.Distribution}}
@@ -937,7 +937,7 @@ display list in machine\-readable format
 .
 .TP
 \-\fBsort\fR=name
-display list in \'name\' or creation \'time\' order
+display list in \(cqname\(cq or creation \(cqtime\(cq order
 .
 .SH "SHOWS DETAILS ABOUT SNAPSHOT"
 \fBaptly\fR \fBsnapshot\fR \fBshow\fR \fIname\fR
@@ -966,7 +966,7 @@ Options:
 show list of packages
 .
 .SH "VERIFY DEPENDENCIES IN SNAPSHOT"
-\fBaptly\fR \fBsnapshot\fR \fBverify\fR \fIname\fR [\fIsource\fR \.\.\.]
+\fBaptly\fR \fBsnapshot\fR \fBverify\fR \fIname\fR [\fIsource\fR \|\.\|\.\|\.]
 .
 .P
 Verify does dependency resolution in snapshot \fIname\fR, possibly using additional snapshots \fIsource\fR as dependency sources\. All unsatisfied dependencies are printed\.
@@ -985,10 +985,10 @@ $ aptly snapshot verify wheezy\-main wheezy\-contrib wheezy\-non\-free
 .IP "" 0
 .
 .SH "PULL PACKAGES FROM ANOTHER SNAPSHOT"
-\fBaptly\fR \fBsnapshot\fR \fBpull\fR \fIname\fR \fIsource\fR \fIdestination\fR \fIpackage\-query\fR \fB\.\.\.\fR
+\fBaptly\fR \fBsnapshot\fR \fBpull\fR \fIname\fR \fIsource\fR \fIdestination\fR \fIpackage\-query\fR \fB\|\.\|\.\|\.\fR
 .
 .P
-Command pull pulls new packages along with its\' dependencies to snapshot \fIname\fR from snapshot \fIsource\fR\. Pull can upgrade package version in \fIname\fR with versions from \fIsource\fR following dependencies\. New snapshot \fIdestination\fR is created as a result of this process\. Packages could be specified simply as \'package\-name\' or as package queries\.
+Command pull pulls new packages along with its\(cq dependencies to snapshot \fIname\fR from snapshot \fIsource\fR\. Pull can upgrade package version in \fIname\fR with versions from \fIsource\fR following dependencies\. New snapshot \fIdestination\fR is created as a result of this process\. Packages could be specified simply as \(cqpackage\-name\(cq or as package queries\.
 .
 .P
 Example:
@@ -1012,15 +1012,15 @@ pull all the packages that satisfy the dependency version requirements
 .
 .TP
 \-\fBdry\-run\fR=false
-don\'t create destination snapshot, just show what would be pulled
+don\(cqt create destination snapshot, just show what would be pulled
 .
 .TP
 \-\fBno\-deps\fR=false
-don\'t process dependencies, just pull listed packages
+don\(cqt process dependencies, just pull listed packages
 .
 .TP
 \-\fBno\-remove\fR=false
-don\'t remove other package versions when pulling package
+don\(cqt remove other package versions when pulling package
 .
 .SH "DIFFERENCE BETWEEN TWO SNAPSHOTS"
 \fBaptly\fR \fBsnapshot\fR \fBdiff\fR \fIname\-a\fR \fIname\-b\fR
@@ -1046,10 +1046,10 @@ Options:
 .
 .TP
 \-\fBonly\-matching\fR=false
-display diff only for matching packages (don\'t display missing packages)
+display diff only for matching packages (don\(cqt display missing packages)
 .
 .SH "MERGES SNAPSHOTS"
-\fBaptly\fR \fBsnapshot\fR \fBmerge\fR \fIdestination\fR \fIsource\fR [\fIsource\fR\.\.\.]
+\fBaptly\fR \fBsnapshot\fR \fBmerge\fR \fIdestination\fR \fIsource\fR [\fIsource\fR\|\.\|\.\|\.]
 .
 .P
 Merge command merges several \fIsource\fR snapshots into one \fIdestination\fR snapshot\. Merge happens from left to right\. By default, packages with the same name\-architecture pair are replaced during merge (package from latest snapshot on the list wins)\. If run with only one source snapshot, merge copies \fIsource\fR into \fIdestination\fR\.
@@ -1076,13 +1076,13 @@ use only the latest version of each package
 .
 .TP
 \-\fBno\-remove\fR=false
-don\'t remove duplicate arch/name packages
+don\(cqt remove duplicate arch/name packages
 .
 .SH "DELETE SNAPSHOT"
 \fBaptly\fR \fBsnapshot\fR \fBdrop\fR \fIname\fR
 .
 .P
-Drop removes information about a snapshot\. If snapshot is published, it can\'t be dropped\.
+Drop removes information about a snapshot\. If snapshot is published, it can\(cqt be dropped\.
 .
 .P
 Example:
@@ -1129,7 +1129,7 @@ Example:
 .
 .nf
 
-$ aptly snapshot search wheezy\-main \'$Architecture (i386), Name (% *\-dev)\'
+$ aptly snapshot search wheezy\-main \(cq$Architecture (i386), Name (% *\-dev)\(cq
 .
 .fi
 .
@@ -1147,10 +1147,10 @@ custom format for result printing
 include dependencies into search results
 .
 .SH "FILTER PACKAGES IN SNAPSHOT PRODUCING ANOTHER SNAPSHOT"
-\fBaptly\fR \fBsnapshot\fR \fBfilter\fR \fIsource\fR \fIdestination\fR \fIpackage\-query\fR \fB\.\.\.\fR
+\fBaptly\fR \fBsnapshot\fR \fBfilter\fR \fIsource\fR \fIdestination\fR \fIpackage\-query\fR \fB\|\.\|\.\|\.\fR
 .
 .P
-Command filter does filtering in snapshot \fIsource\fR, producing another snapshot \fIdestination\fR\. Packages could be specified simply as \'package\-name\' or as package queries\.
+Command filter does filtering in snapshot \fIsource\fR, producing another snapshot \fIdestination\fR\. Packages could be specified simply as \(cqpackage\-name\(cq or as package queries\.
 .
 .P
 Example:
@@ -1159,7 +1159,7 @@ Example:
 .
 .nf
 
-$ aptly snapshot filter wheezy\-main wheezy\-required \'Priorioty (required)\'
+$ aptly snapshot filter wheezy\-main wheezy\-required \(cqPriorioty (required)\(cq
 .
 .fi
 .
@@ -1308,11 +1308,11 @@ GPG secret keyring to use (instead of default)
 .
 .TP
 \-\fBskip\-contents\fR=false
-don\'t generate Contents indexes
+don\(cqt generate Contents indexes
 .
 .TP
 \-\fBskip\-signing\fR=false
-don\'t sign Release files with GPG
+don\(cqt sign Release files with GPG
 .
 .SH "PUBLISH SNAPSHOT"
 \fBaptly\fR \fBpublish\fR \fBsnapshot\fR \fIname\fR [[\fIendpoint\fR:]\fIprefix\fR]
@@ -1395,11 +1395,11 @@ GPG secret keyring to use (instead of default)
 .
 .TP
 \-\fBskip\-contents\fR=false
-don\'t generate Contents indexes
+don\(cqt generate Contents indexes
 .
 .TP
 \-\fBskip\-signing\fR=false
-don\'t sign Release files with GPG
+don\(cqt sign Release files with GPG
 .
 .SH "UPDATE PUBLISHED REPOSITORY BY SWITCHING TO NEW SNAPSHOT"
 \fBaptly\fR \fBpublish\fR \fBswitch\fR \fIdistribution\fR [[\fIendpoint\fR:]\fIprefix\fR] \fInew\-snapshot\fR
@@ -1473,11 +1473,11 @@ GPG secret keyring to use (instead of default)
 .
 .TP
 \-\fBskip\-contents\fR=false
-don\'t generate Contents indexes
+don\(cqt generate Contents indexes
 .
 .TP
 \-\fBskip\-signing\fR=false
-don\'t sign Release files with GPG
+don\(cqt sign Release files with GPG
 .
 .SH "UPDATE PUBLISHED LOCAL REPOSITORY"
 \fBaptly\fR \fBpublish\fR \fBupdate\fR \fIdistribution\fR [[\fIendpoint\fR:]\fIprefix\fR]
@@ -1534,11 +1534,11 @@ GPG secret keyring to use (instead of default)
 .
 .TP
 \-\fBskip\-contents\fR=false
-don\'t generate Contents indexes
+don\(cqt generate Contents indexes
 .
 .TP
 \-\fBskip\-signing\fR=false
-don\'t sign Release files with GPG
+don\(cqt sign Release files with GPG
 .
 .SH "SHOWS DETAILS OF PUBLISHED REPOSITORY"
 \fBaptly\fR \fBpublish\fR \fBshow\fR \fIdistribution\fR [[\fIendpoint\fR:]\fIprefix\fR]
@@ -1572,7 +1572,7 @@ Example:
 .
 .nf
 
-$ aptly package search \'$Architecture (i386), Name (% *\-dev)\'
+$ aptly package search \(cq$Architecture (i386), Name (% *\-dev)\(cq
 .
 .fi
 .
@@ -1598,7 +1598,7 @@ Example:
 .
 .nf
 
-$ aptly package show \'nginx\-light_1\.2\.1\-2\.2+wheezy2_i386\'
+$ aptly package show \(cqnginx\-light_1\.2\.1\-2\.2+wheezy2_i386\(cq
 .
 .fi
 .
@@ -1619,7 +1619,7 @@ display information about mirrors, snapshots and local repos referencing this pa
 \fBaptly\fR \fBdb\fR \fBcleanup\fR
 .
 .P
-Database cleanup removes information about unreferenced packages and removes files in the package pool that aren\'t used by packages anymore
+Database cleanup removes information about unreferenced packages and removes files in the package pool that aren\(cqt used by packages anymore
 .
 .P
 Example:
@@ -1632,7 +1632,7 @@ Options:
 .
 .TP
 \-\fBdry\-run\fR=false
-don\'t delete anything
+don\(cqt delete anything
 .
 .TP
 \-\fBverbose\fR=false
@@ -1642,7 +1642,7 @@ be verbose when loading objects/removing them
 \fBaptly\fR \fBdb\fR \fBrecover\fR
 .
 .P
-Database recover does its\' best to recover the database after a crash\. It is recommended to backup the DB before running recover\.
+Database recover does its\(cq best to recover the database after a crash\. It is recommended to backup the DB before running recover\.
 .
 .P
 Example:
@@ -1654,7 +1654,7 @@ $ aptly db recover
 \fBaptly\fR \fBserve\fR
 .
 .P
-Command serve starts embedded HTTP server (not suitable for real production usage) to serve contents of public/ subdirectory of aptly\'s root that contains published repositories\.
+Command serve starts embedded HTTP server (not suitable for real production usage) to serve contents of public/ subdirectory of aptly\(cqs root that contains published repositories\.
 .
 .P
 Example:
@@ -1690,7 +1690,7 @@ host:port for HTTP listening
 .
 .TP
 \-\fBno\-lock\fR=false
-don\'t lock the database
+don\(cqt lock the database
 .
 .SH "RENDER GRAPH OF RELATIONSHIPS"
 \fBaptly\fR \fBgraph\fR
@@ -1715,7 +1715,7 @@ render graph to specified format (png, svg, pdf, etc\.)
 \-\fBoutput\fR=
 specify output filename, default is to open result in viewer
 .
-.SH "SHOW CURRENT APTLY\'S CONFIG"
+.SH "SHOW CURRENT APTLY\(cqS CONFIG"
 \fBaptly\fR \fBconfig\fR \fBshow\fR
 .
 .P
@@ -1728,7 +1728,7 @@ Example:
 $ aptly config show
 .
 .SH "RUN APTLY TASKS"
-\fBaptly\fR \fBtask\fR \fBrun\fR \-filename=\fIfilename\fR \fB|\fR \fIcommand1\fR, \fIcommand2\fR, \fB\.\.\.\fR
+\fBaptly\fR \fBtask\fR \fBrun\fR \-filename=\fIfilename\fR \fB|\fR \fIcommand1\fR, \fIcommand2\fR, \fB\|\.\|\.\|\.\fR
 .
 .P
 Command helps organise multiple aptly commands in one single aptly task, running as single thread\.
@@ -1758,7 +1758,7 @@ Options:
 \-\fBfilename\fR=
 specifies the filename that contains the commands to run
 .
-.SH "SHOW CURRENT APTLY\'S CONFIG"
+.SH "SHOW CURRENT APTLY\(cqS CONFIG"
 \fBaptly\fR \fBconfig\fR \fBshow\fR
 .
 .P
@@ -1791,73 +1791,73 @@ command parse failure
 .SH "AUTHORS"
 List of contributors, in chronological order:
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Andrey Smirnov (https://github\.com/smira)
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Sebastien Binet (https://github\.com/sbinet)
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Ryan Uber (https://github\.com/ryanuber)
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Simon Aquino (https://github\.com/queeno)
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Vincent Batoufflet (https://github\.com/vbatoufflet)
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Ivan Kurnosov (https://github\.com/zerkms)
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Dmitrii Kashin (https://github\.com/freehck)
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Chris Read (https://github\.com/cread)
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Rohan Garg (https://github\.com/shadeslayer)
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Russ Allbery (https://github\.com/rra)
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Sylvain Baubeau (https://github\.com/lebauce)
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Andrea Bernardo Ciddio (https://github\.com/bcandrea)
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Michael Koval (https://github\.com/mkoval)
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Alexander Guy (https://github\.com/alexanderguy)
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Sebastien Badia (https://github\.com/sbadia)
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Szymon Sobik (https://github\.com/sobczyk)
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Paul Krohn (https://github\.com/paul\-krohn)
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Vincent Bernat (https://github\.com/vincentbernat)
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 x539 (https://github\.com/x539)
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Phil Frost (https://github\.com/bitglue)
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Benoit Foucher (https://github\.com/bentoi)
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Geoffrey Thomas (https://github\.com/geofft)
 .
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Oliver Sauder (https://github\.com/sliverc)
 .
 .IP "" 0

--- a/man/aptly.1
+++ b/man/aptly.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "APTLY" "1" "November 2016" "" ""
+.TH "APTLY" "1" "2017-01-10" "" ""
 .
 .SH "NAME"
 \fBaptly\fR \- Debian repository management tool
@@ -10,7 +10,7 @@
 Common command format:
 .
 .P
-\fBaptly\fR [\fIglobal options\fR\|\.\|\.\|\.] \fIcommand\fR \fIsubcommand\fR [\fIoptions\fR\|\.\|\.\|\.] \fIarguments\fR
+\fBaptly\fR [\fIglobal options\fR\.\.\.] \fIcommand\fR \fIsubcommand\fR [\fIoptions\fR\.\.\.] \fIarguments\fR
 .
 .P
 aptly has integrated help that matches contents of this manual page, to get help, prepend \fBhelp\fR to command name:
@@ -22,7 +22,7 @@ aptly has integrated help that matches contents of this manual page, to get help
 aptly is a tool to create partial and full mirrors of remote repositories, manage local repositories, filter them, merge, upgrade individual packages, take snapshots and publish them back as Debian repositories\.
 .
 .P
-aptly\(cqs goal is to establish repeatability and controlled changes in a package\-centric environment\. aptly allows one to fix a set of packages in a repository, so that package installation and upgrade becomes deterministic\. At the same time aptly allows one to perform controlled, fine\-grained changes in repository contents to transition your package environment to new version\.
+aptly\'s goal is to establish repeatability and controlled changes in a package\-centric environment\. aptly allows one to fix a set of packages in a repository, so that package installation and upgrade becomes deterministic\. At the same time aptly allows one to perform controlled, fine\-grained changes in repository contents to transition your package environment to new version\.
 .
 .SH "CONFIGURATION"
 aptly looks for configuration file first in \fB~/\.aptly\.conf\fR then in \fB/etc/aptly\.conf\fR and, if no config file found, new one is created in home directory\. If \fB\-config=\fR flag is specified, aptly would use config file at specified location\. Also aptly needs root directory for database, package and published repository storage\. If not specified, directory defaults to \fB~/\.aptly\fR, it will be created if missing\.
@@ -120,11 +120,11 @@ follow dependency from binary package to source package
 .
 .TP
 \fBgpgDisableSign\fR
-don\(cqt sign published repositories with gpg(1), also can be disabled on per\-repo basis using \fB\-skip\-signing\fR flag when publishing
+don\'t sign published repositories with gpg(1), also can be disabled on per\-repo basis using \fB\-skip\-signing\fR flag when publishing
 .
 .TP
 \fBgpgDisableVerify\fR
-don\(cqt verify remote mirrors with gpg(1), also can be disabled on per\-mirror basis using \fB\-ignore\-signatures\fR flag when creating and updating mirrors
+don\'t verify remote mirrors with gpg(1), also can be disabled on per\-mirror basis using \fB\-ignore\-signatures\fR flag when creating and updating mirrors
 .
 .TP
 \fBdownloadSourcePackages\fR
@@ -238,22 +238,22 @@ syntax is the same as for dependency conditions, but instead of package name fie
 .P
 Supported fields:
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 all field names from Debian package control files are supported except for \fBFilename\fR, \fBMD5sum\fR, \fBSHA1\fR, \fBSHA256\fR, \fBSize\fR, \fBFiles\fR, \fBChecksums\-SHA1\fR, \fBChecksums\-SHA256\fR\.
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB$Source\fR is a name of source package (for binary packages)
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB$SourceVersion\fR is a version of source package
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB$Architecture\fR is \fBArchitecture\fR for binary packages and \fBsource\fR for source packages, when matching with equal (\fB=\fR) operator, package with \fBany\fR architecture matches all architectures but \fBsource\fR\.
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB$Version\fR has the same value as \fBVersion\fR, but comparison operators use Debian version precedence rules
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB$PackageType\fR is \fBdeb\fR for binary packages and \fBsource\fR for source packages
 .
 .IP "" 0
@@ -278,7 +278,7 @@ pattern matching, like shell patterns, supported special symbols are: \fB[^]?*\f
 regular expression matching, e\.g\.: \fBName (~ \.*\-dev)\fR
 .
 .P
-Simple terms could be combined into more complex queries using operators \fB,\fR (and), \fB|\fR (or) and \fB!\fR (not), parentheses \fB()\fR are used to change operator precedence\. Match value could be enclosed in single (\fB\(cq\fR) or double (\fB"\fR) quotes if required to resolve ambiguity, quotes inside quoted string should escaped with slash (\fB\e\fR)\.
+Simple terms could be combined into more complex queries using operators \fB,\fR (and), \fB|\fR (or) and \fB!\fR (not), parentheses \fB()\fR are used to change operator precedence\. Match value could be enclosed in single (\fB\'\fR) or double (\fB"\fR) quotes if required to resolve ambiguity, quotes inside quoted string should escaped with slash (\fB\e\fR)\.
 .
 .P
 Examples:
@@ -315,10 +315,10 @@ matches all packages that provide \fBmail\-transport\fR with name that has no su
 When specified on command line, query may have to be quoted according to shell rules, so that it stays single argument:
 .
 .P
-\fBaptly repo import percona stable \(cqmysql\-client (>= 3\.6)\(cq\fR
+\fBaptly repo import percona stable \'mysql\-client (>= 3\.6)\'\fR
 .
 .SH "PACKAGE DISPLAY FORMAT"
-Some aptly commands (\fBaptly mirror search\fR, \fBaptly package search\fR, \|\.\|\.\|\.) support \fB\-format\fR flag which allows to customize how search results are printed\. Golang templates are used to specify display format, with all package stanza fields available to template\. In addition to package stanza fields aptly provides:
+Some aptly commands (\fBaptly mirror search\fR, \fBaptly package search\fR, \.\.\.) support \fB\-format\fR flag which allows to customize how search results are printed\. Golang templates are used to specify display format, with all package stanza fields available to template\. In addition to package stanza fields aptly provides:
 .
 .TP
 \fBKey\fR
@@ -330,7 +330,7 @@ hash that includes MD5 of all packages files\.
 .
 .TP
 \fBShortKey\fR
-package ID, which is unique in single list (mirror, repo, snapshot, \|\.\|\.\|\.), but not unique in whole aptly package collection\.
+package ID, which is unique in single list (mirror, repo, snapshot, \.\.\.), but not unique in whole aptly package collection\.
 .
 .P
 For example, default aptly display format could be presented with the following template: \fB{{\.Package}}_{{\.Version}}_{{\.Architecture}}\fR\. To display package name with dependencies: \fB{{\.Package}} | {{\.Depends}}\fR\. More information on Golang template syntax: http://godoc\.org/text/template
@@ -347,7 +347,7 @@ location of configuration file (default locations are /etc/aptly\.conf, ~/\.aptl
 .
 .TP
 \-\fBdep\-follow\-all\-variants\fR=false
-when processing dependencies, follow a & b if dependency is \(cqa|b\(cq
+when processing dependencies, follow a & b if dependency is \'a|b\'
 .
 .TP
 \-\fBdep\-follow\-recommends\fR=false
@@ -362,10 +362,10 @@ when processing dependencies, follow from binary to Source packages
 when processing dependencies, follow Suggests
 .
 .SH "CREATE NEW MIRROR"
-\fBaptly\fR \fBmirror\fR \fBcreate\fR \fIname\fR \fIarchive url\fR \fIdistribution\fR [\fIcomponent1\fR \|\.\|\.\|\.]
+\fBaptly\fR \fBmirror\fR \fBcreate\fR \fIname\fR \fIarchive url\fR \fIdistribution\fR [\fIcomponent1\fR \.\.\.]
 .
 .P
-Creates mirror \fIname\fR of remote repository, aptly supports both regular and flat Debian repositories exported via HTTP and FTP\. aptly would try download Release file from remote repository and verify its\(cq signature\. Command line format resembles apt utlitily sources\.list(5)\.
+Creates mirror \fIname\fR of remote repository, aptly supports both regular and flat Debian repositories exported via HTTP and FTP\. aptly would try download Release file from remote repository and verify its\' signature\. Command line format resembles apt utlitily sources\.list(5)\.
 .
 .P
 PPA urls could specified in short format:
@@ -506,6 +506,10 @@ disable verification of Release file signatures
 \-\fBkeyring\fR=
 gpg keyring to use when verifying Release file (could be specified multiple times)
 .
+.TP
+\-\fBmax\-tries\fR=1
+max download tries till process fails with download error
+.
 .SH "RENAMES MIRROR"
 \fBaptly\fR \fBmirror\fR \fBrename\fR \fIold\-name\fR \fInew\-name\fR
 .
@@ -562,7 +566,7 @@ Example:
 .
 .nf
 
-$ aptly mirror search wheezy\-main \(cq$Architecture (i386), Name (% *\-dev)\(cq
+$ aptly mirror search wheezy\-main \'$Architecture (i386), Name (% *\-dev)\'
 .
 .fi
 .
@@ -603,7 +607,7 @@ when adding package that conflicts with existing package, remove existing packag
 remove files that have been imported successfully into repository
 .
 .SH "COPY PACKAGES BETWEEN LOCAL REPOSITORIES"
-\fBaptly\fR \fBrepo\fR \fBcopy\fR \fIsrc\-name\fR \fIdst\-name\fR \fIpackage\-query\fR \fB\|\.\|\.\|\.\fR
+\fBaptly\fR \fBrepo\fR \fBcopy\fR \fIsrc\-name\fR \fIdst\-name\fR \fIpackage\-query\fR \fB\.\.\.\fR
 .
 .P
 Command copy copies packages matching \fIpackage\-query\fR from local repo \fIsrc\-name\fR to local repo \fIdst\-name\fR\.
@@ -612,14 +616,14 @@ Command copy copies packages matching \fIpackage\-query\fR from local repo \fIsr
 Example:
 .
 .P
-$ aptly repo copy testing stable \(cqmyapp (=0\.1\.12)\(cq
+$ aptly repo copy testing stable \'myapp (=0\.1\.12)\'
 .
 .P
 Options:
 .
 .TP
 \-\fBdry\-run\fR=false
-don\(cqt copy, just show what would be copied
+don\'t copy, just show what would be copied
 .
 .TP
 \-\fBwith\-deps\fR=false
@@ -707,7 +711,7 @@ default distribution when publishing
 uploaders\.json to be used when including \.changes into this repository
 .
 .SH "IMPORT PACKAGES FROM MIRROR TO LOCAL REPOSITORY"
-\fBaptly\fR \fBrepo\fR \fBimport\fR \fIsrc\-mirror\fR \fIdst\-repo\fR \fIpackage\-query\fR \fB\|\.\|\.\|\.\fR
+\fBaptly\fR \fBrepo\fR \fBimport\fR \fIsrc\-mirror\fR \fIdst\-repo\fR \fIpackage\-query\fR \fB\.\.\.\fR
 .
 .P
 Command import looks up packages matching \fIpackage\-query\fR in mirror \fIsrc\-mirror\fR and copies them to local repo \fIdst\-repo\fR\.
@@ -723,7 +727,7 @@ Options:
 .
 .TP
 \-\fBdry\-run\fR=false
-don\(cqt import, just show what would be imported
+don\'t import, just show what would be imported
 .
 .TP
 \-\fBwith\-deps\fR=false
@@ -749,7 +753,7 @@ Options:
 display list in machine\-readable format
 .
 .SH "MOVE PACKAGES BETWEEN LOCAL REPOSITORIES"
-\fBaptly\fR \fBrepo\fR \fBmove\fR \fIsrc\-name\fR \fIdst\-name\fR \fIpackage\-query\fR \fB\|\.\|\.\|\.\fR
+\fBaptly\fR \fBrepo\fR \fBmove\fR \fIsrc\-name\fR \fIdst\-name\fR \fIpackage\-query\fR \fB\.\.\.\fR
 .
 .P
 Command move moves packages matching \fIpackage\-query\fR from local repo \fIsrc\-name\fR to local repo \fIdst\-name\fR\.
@@ -758,37 +762,37 @@ Command move moves packages matching \fIpackage\-query\fR from local repo \fIsrc
 Example:
 .
 .P
-$ aptly repo move testing stable \(cqmyapp (=0\.1\.12)\(cq
+$ aptly repo move testing stable \'myapp (=0\.1\.12)\'
 .
 .P
 Options:
 .
 .TP
 \-\fBdry\-run\fR=false
-don\(cqt move, just show what would be moved
+don\'t move, just show what would be moved
 .
 .TP
 \-\fBwith\-deps\fR=false
 follow dependencies when processing package\-spec
 .
 .SH "REMOVE PACKAGES FROM LOCAL REPOSITORY"
-\fBaptly\fR \fBrepo\fR \fBremove\fR \fIname\fR \fIpackage\-query\fR \fB\|\.\|\.\|\.\fR
+\fBaptly\fR \fBrepo\fR \fBremove\fR \fIname\fR \fIpackage\-query\fR \fB\.\.\.\fR
 .
 .P
-Commands removes packages matching \fIpackage\-query\fR from local repository \fIname\fR\. If removed packages are not referenced by other repos or snapshots, they can be removed completely (including files) by running \(cqaptly db cleanup\(cq\.
+Commands removes packages matching \fIpackage\-query\fR from local repository \fIname\fR\. If removed packages are not referenced by other repos or snapshots, they can be removed completely (including files) by running \'aptly db cleanup\'\.
 .
 .P
 Example:
 .
 .P
-$ aptly repo remove testing \(cqmyapp (=0\.1\.12)\(cq
+$ aptly repo remove testing \'myapp (=0\.1\.12)\'
 .
 .P
 Options:
 .
 .TP
 \-\fBdry\-run\fR=false
-don\(cqt remove, just show what would be removed
+don\'t remove, just show what would be removed
 .
 .SH "SHOW DETAILS ABOUT LOCAL REPOSITORY"
 \fBaptly\fR \fBrepo\fR \fBshow\fR \fIname\fR
@@ -831,7 +835,7 @@ Example:
 .
 .nf
 
-$ aptly repo search my\-software \(cq$Architecture (i386), Name (% *\-dev)\(cq
+$ aptly repo search my\-software \'$Architecture (i386), Name (% *\-dev)\'
 .
 .fi
 .
@@ -849,7 +853,7 @@ custom format for result printing
 include dependencies into search results
 .
 .SH "ADD PACKAGES TO LOCAL REPOSITORIES BASED ON \.CHANGES FILES"
-\fBaptly\fR \fBrepo\fR \fBinclude\fR <file\.changes>|\fIdirectory\fR \fB\|\.\|\.\|\.\fR
+\fBaptly\fR \fBrepo\fR \fBinclude\fR <file\.changes>|\fIdirectory\fR \fB\.\.\.\fR
 .
 .P
 Command include looks for \.changes files in list of arguments or specified directories\. Each \.changes file is verified, parsed, referenced files are put into separate temporary directory and added into local repository\. Successfully imported files are removed by default\.
@@ -884,7 +888,7 @@ gpg keyring to use when verifying Release file (could be specified multiple time
 .
 .TP
 \-\fBno\-remove\-files\fR=false
-don\(cqt remove files that have been imported successfully into repository
+don\'t remove files that have been imported successfully into repository
 .
 .TP
 \-\fBrepo\fR={{\.Distribution}}
@@ -933,7 +937,7 @@ display list in machine\-readable format
 .
 .TP
 \-\fBsort\fR=name
-display list in \(cqname\(cq or creation \(cqtime\(cq order
+display list in \'name\' or creation \'time\' order
 .
 .SH "SHOWS DETAILS ABOUT SNAPSHOT"
 \fBaptly\fR \fBsnapshot\fR \fBshow\fR \fIname\fR
@@ -962,7 +966,7 @@ Options:
 show list of packages
 .
 .SH "VERIFY DEPENDENCIES IN SNAPSHOT"
-\fBaptly\fR \fBsnapshot\fR \fBverify\fR \fIname\fR [\fIsource\fR \|\.\|\.\|\.]
+\fBaptly\fR \fBsnapshot\fR \fBverify\fR \fIname\fR [\fIsource\fR \.\.\.]
 .
 .P
 Verify does dependency resolution in snapshot \fIname\fR, possibly using additional snapshots \fIsource\fR as dependency sources\. All unsatisfied dependencies are printed\.
@@ -981,10 +985,10 @@ $ aptly snapshot verify wheezy\-main wheezy\-contrib wheezy\-non\-free
 .IP "" 0
 .
 .SH "PULL PACKAGES FROM ANOTHER SNAPSHOT"
-\fBaptly\fR \fBsnapshot\fR \fBpull\fR \fIname\fR \fIsource\fR \fIdestination\fR \fIpackage\-query\fR \fB\|\.\|\.\|\.\fR
+\fBaptly\fR \fBsnapshot\fR \fBpull\fR \fIname\fR \fIsource\fR \fIdestination\fR \fIpackage\-query\fR \fB\.\.\.\fR
 .
 .P
-Command pull pulls new packages along with its\(cq dependencies to snapshot \fIname\fR from snapshot \fIsource\fR\. Pull can upgrade package version in \fIname\fR with versions from \fIsource\fR following dependencies\. New snapshot \fIdestination\fR is created as a result of this process\. Packages could be specified simply as \(cqpackage\-name\(cq or as package queries\.
+Command pull pulls new packages along with its\' dependencies to snapshot \fIname\fR from snapshot \fIsource\fR\. Pull can upgrade package version in \fIname\fR with versions from \fIsource\fR following dependencies\. New snapshot \fIdestination\fR is created as a result of this process\. Packages could be specified simply as \'package\-name\' or as package queries\.
 .
 .P
 Example:
@@ -1008,15 +1012,15 @@ pull all the packages that satisfy the dependency version requirements
 .
 .TP
 \-\fBdry\-run\fR=false
-don\(cqt create destination snapshot, just show what would be pulled
+don\'t create destination snapshot, just show what would be pulled
 .
 .TP
 \-\fBno\-deps\fR=false
-don\(cqt process dependencies, just pull listed packages
+don\'t process dependencies, just pull listed packages
 .
 .TP
 \-\fBno\-remove\fR=false
-don\(cqt remove other package versions when pulling package
+don\'t remove other package versions when pulling package
 .
 .SH "DIFFERENCE BETWEEN TWO SNAPSHOTS"
 \fBaptly\fR \fBsnapshot\fR \fBdiff\fR \fIname\-a\fR \fIname\-b\fR
@@ -1042,10 +1046,10 @@ Options:
 .
 .TP
 \-\fBonly\-matching\fR=false
-display diff only for matching packages (don\(cqt display missing packages)
+display diff only for matching packages (don\'t display missing packages)
 .
 .SH "MERGES SNAPSHOTS"
-\fBaptly\fR \fBsnapshot\fR \fBmerge\fR \fIdestination\fR \fIsource\fR [\fIsource\fR\|\.\|\.\|\.]
+\fBaptly\fR \fBsnapshot\fR \fBmerge\fR \fIdestination\fR \fIsource\fR [\fIsource\fR\.\.\.]
 .
 .P
 Merge command merges several \fIsource\fR snapshots into one \fIdestination\fR snapshot\. Merge happens from left to right\. By default, packages with the same name\-architecture pair are replaced during merge (package from latest snapshot on the list wins)\. If run with only one source snapshot, merge copies \fIsource\fR into \fIdestination\fR\.
@@ -1072,13 +1076,13 @@ use only the latest version of each package
 .
 .TP
 \-\fBno\-remove\fR=false
-don\(cqt remove duplicate arch/name packages
+don\'t remove duplicate arch/name packages
 .
 .SH "DELETE SNAPSHOT"
 \fBaptly\fR \fBsnapshot\fR \fBdrop\fR \fIname\fR
 .
 .P
-Drop removes information about a snapshot\. If snapshot is published, it can\(cqt be dropped\.
+Drop removes information about a snapshot\. If snapshot is published, it can\'t be dropped\.
 .
 .P
 Example:
@@ -1125,7 +1129,7 @@ Example:
 .
 .nf
 
-$ aptly snapshot search wheezy\-main \(cq$Architecture (i386), Name (% *\-dev)\(cq
+$ aptly snapshot search wheezy\-main \'$Architecture (i386), Name (% *\-dev)\'
 .
 .fi
 .
@@ -1143,10 +1147,10 @@ custom format for result printing
 include dependencies into search results
 .
 .SH "FILTER PACKAGES IN SNAPSHOT PRODUCING ANOTHER SNAPSHOT"
-\fBaptly\fR \fBsnapshot\fR \fBfilter\fR \fIsource\fR \fIdestination\fR \fIpackage\-query\fR \fB\|\.\|\.\|\.\fR
+\fBaptly\fR \fBsnapshot\fR \fBfilter\fR \fIsource\fR \fIdestination\fR \fIpackage\-query\fR \fB\.\.\.\fR
 .
 .P
-Command filter does filtering in snapshot \fIsource\fR, producing another snapshot \fIdestination\fR\. Packages could be specified simply as \(cqpackage\-name\(cq or as package queries\.
+Command filter does filtering in snapshot \fIsource\fR, producing another snapshot \fIdestination\fR\. Packages could be specified simply as \'package\-name\' or as package queries\.
 .
 .P
 Example:
@@ -1155,7 +1159,7 @@ Example:
 .
 .nf
 
-$ aptly snapshot filter wheezy\-main wheezy\-required \(cqPriorioty (required)\(cq
+$ aptly snapshot filter wheezy\-main wheezy\-required \'Priorioty (required)\'
 .
 .fi
 .
@@ -1304,11 +1308,11 @@ GPG secret keyring to use (instead of default)
 .
 .TP
 \-\fBskip\-contents\fR=false
-don\(cqt generate Contents indexes
+don\'t generate Contents indexes
 .
 .TP
 \-\fBskip\-signing\fR=false
-don\(cqt sign Release files with GPG
+don\'t sign Release files with GPG
 .
 .SH "PUBLISH SNAPSHOT"
 \fBaptly\fR \fBpublish\fR \fBsnapshot\fR \fIname\fR [[\fIendpoint\fR:]\fIprefix\fR]
@@ -1391,11 +1395,11 @@ GPG secret keyring to use (instead of default)
 .
 .TP
 \-\fBskip\-contents\fR=false
-don\(cqt generate Contents indexes
+don\'t generate Contents indexes
 .
 .TP
 \-\fBskip\-signing\fR=false
-don\(cqt sign Release files with GPG
+don\'t sign Release files with GPG
 .
 .SH "UPDATE PUBLISHED REPOSITORY BY SWITCHING TO NEW SNAPSHOT"
 \fBaptly\fR \fBpublish\fR \fBswitch\fR \fIdistribution\fR [[\fIendpoint\fR:]\fIprefix\fR] \fInew\-snapshot\fR
@@ -1469,11 +1473,11 @@ GPG secret keyring to use (instead of default)
 .
 .TP
 \-\fBskip\-contents\fR=false
-don\(cqt generate Contents indexes
+don\'t generate Contents indexes
 .
 .TP
 \-\fBskip\-signing\fR=false
-don\(cqt sign Release files with GPG
+don\'t sign Release files with GPG
 .
 .SH "UPDATE PUBLISHED LOCAL REPOSITORY"
 \fBaptly\fR \fBpublish\fR \fBupdate\fR \fIdistribution\fR [[\fIendpoint\fR:]\fIprefix\fR]
@@ -1530,11 +1534,30 @@ GPG secret keyring to use (instead of default)
 .
 .TP
 \-\fBskip\-contents\fR=false
-don\(cqt generate Contents indexes
+don\'t generate Contents indexes
 .
 .TP
 \-\fBskip\-signing\fR=false
-don\(cqt sign Release files with GPG
+don\'t sign Release files with GPG
+.
+.SH "SHOWS DETAILS OF PUBLISHED REPOSITORY"
+\fBaptly\fR \fBpublish\fR \fBshow\fR \fIdistribution\fR [[\fIendpoint\fR:]\fIprefix\fR]
+.
+.P
+Command show displays full information of a published repository\.
+.
+.P
+Example:
+.
+.IP "" 4
+.
+.nf
+
+$ aptly publish show wheezy
+.
+.fi
+.
+.IP "" 0
 .
 .SH "SEARCH FOR PACKAGES MATCHING QUERY"
 \fBaptly\fR \fBpackage\fR \fBsearch\fR \fIpackage\-query\fR
@@ -1549,7 +1572,7 @@ Example:
 .
 .nf
 
-$ aptly package search \(cq$Architecture (i386), Name (% *\-dev)\(cq
+$ aptly package search \'$Architecture (i386), Name (% *\-dev)\'
 .
 .fi
 .
@@ -1575,7 +1598,7 @@ Example:
 .
 .nf
 
-$ aptly package show \(cqnginx\-light_1\.2\.1\-2\.2+wheezy2_i386\(cq
+$ aptly package show \'nginx\-light_1\.2\.1\-2\.2+wheezy2_i386\'
 .
 .fi
 .
@@ -1596,7 +1619,7 @@ display information about mirrors, snapshots and local repos referencing this pa
 \fBaptly\fR \fBdb\fR \fBcleanup\fR
 .
 .P
-Database cleanup removes information about unreferenced packages and removes files in the package pool that aren\(cqt used by packages anymore
+Database cleanup removes information about unreferenced packages and removes files in the package pool that aren\'t used by packages anymore
 .
 .P
 Example:
@@ -1609,7 +1632,7 @@ Options:
 .
 .TP
 \-\fBdry\-run\fR=false
-don\(cqt delete anything
+don\'t delete anything
 .
 .TP
 \-\fBverbose\fR=false
@@ -1619,7 +1642,7 @@ be verbose when loading objects/removing them
 \fBaptly\fR \fBdb\fR \fBrecover\fR
 .
 .P
-Database recover does its\(cq best to recover the database after a crash\. It is recommended to backup the DB before running recover\.
+Database recover does its\' best to recover the database after a crash\. It is recommended to backup the DB before running recover\.
 .
 .P
 Example:
@@ -1631,7 +1654,7 @@ $ aptly db recover
 \fBaptly\fR \fBserve\fR
 .
 .P
-Command serve starts embedded HTTP server (not suitable for real production usage) to serve contents of public/ subdirectory of aptly\(cqs root that contains published repositories\.
+Command serve starts embedded HTTP server (not suitable for real production usage) to serve contents of public/ subdirectory of aptly\'s root that contains published repositories\.
 .
 .P
 Example:
@@ -1667,7 +1690,7 @@ host:port for HTTP listening
 .
 .TP
 \-\fBno\-lock\fR=false
-don\(cqt lock the database
+don\'t lock the database
 .
 .SH "RENDER GRAPH OF RELATIONSHIPS"
 \fBaptly\fR \fBgraph\fR
@@ -1692,7 +1715,7 @@ render graph to specified format (png, svg, pdf, etc\.)
 \-\fBoutput\fR=
 specify output filename, default is to open result in viewer
 .
-.SH "SHOW CURRENT APTLY\(cqS CONFIG"
+.SH "SHOW CURRENT APTLY\'S CONFIG"
 \fBaptly\fR \fBconfig\fR \fBshow\fR
 .
 .P
@@ -1705,7 +1728,7 @@ Example:
 $ aptly config show
 .
 .SH "RUN APTLY TASKS"
-\fBaptly\fR \fBtask\fR \fBrun\fR \-filename=\fIfilename\fR \fB|\fR \fIcommand1\fR, \fIcommand2\fR, \fB\|\.\|\.\|\.\fR
+\fBaptly\fR \fBtask\fR \fBrun\fR \-filename=\fIfilename\fR \fB|\fR \fIcommand1\fR, \fIcommand2\fR, \fB\.\.\.\fR
 .
 .P
 Command helps organise multiple aptly commands in one single aptly task, running as single thread\.
@@ -1735,7 +1758,7 @@ Options:
 \-\fBfilename\fR=
 specifies the filename that contains the commands to run
 .
-.SH "SHOW CURRENT APTLY\(cqS CONFIG"
+.SH "SHOW CURRENT APTLY\'S CONFIG"
 \fBaptly\fR \fBconfig\fR \fBshow\fR
 .
 .P
@@ -1768,71 +1791,74 @@ command parse failure
 .SH "AUTHORS"
 List of contributors, in chronological order:
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 Andrey Smirnov (https://github\.com/smira)
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 Sebastien Binet (https://github\.com/sbinet)
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 Ryan Uber (https://github\.com/ryanuber)
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 Simon Aquino (https://github\.com/queeno)
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 Vincent Batoufflet (https://github\.com/vbatoufflet)
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 Ivan Kurnosov (https://github\.com/zerkms)
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 Dmitrii Kashin (https://github\.com/freehck)
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 Chris Read (https://github\.com/cread)
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 Rohan Garg (https://github\.com/shadeslayer)
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 Russ Allbery (https://github\.com/rra)
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 Sylvain Baubeau (https://github\.com/lebauce)
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 Andrea Bernardo Ciddio (https://github\.com/bcandrea)
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 Michael Koval (https://github\.com/mkoval)
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 Alexander Guy (https://github\.com/alexanderguy)
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 Sebastien Badia (https://github\.com/sbadia)
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 Szymon Sobik (https://github\.com/sobczyk)
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 Paul Krohn (https://github\.com/paul\-krohn)
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 Vincent Bernat (https://github\.com/vincentbernat)
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 x539 (https://github\.com/x539)
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 Phil Frost (https://github\.com/bitglue)
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 Benoit Foucher (https://github\.com/bentoi)
 .
-.IP "\[ci]" 4
+.IP "\(bu" 4
 Geoffrey Thomas (https://github\.com/geofft)
+.
+.IP "\(bu" 4
+Oliver Sauder (https://github\.com/sliverc)
 .
 .IP "" 0
 

--- a/system/t05_snapshot/CreateSnapshot1Test_snapshot_show
+++ b/system/t05_snapshot/CreateSnapshot1Test_snapshot_show
@@ -2,6 +2,8 @@ Name: snap1
 Created At: 2014-06-29 01:43:01 MSK
 Description: Snapshot from mirror [wheezy-main]: http://mirror.yandex.ru/debian/ wheezy
 Number of packages: 56121
+Sources:
+  wheezy-main [repo]
 Packages:
   0ad-data_0~r11863-1_all
   2ping_2.0-1_all

--- a/system/t05_snapshot/CreateSnapshot6Test_snapshot_show
+++ b/system/t05_snapshot/CreateSnapshot6Test_snapshot_show
@@ -1,6 +1,8 @@
 Name: snap6
 Description: Snapshot from local repo [local-repo]
 Number of packages: 3
+Sources:
+  local-repo [local]
 Packages:
   libboost-program-options-dev_1.49.0.1_i386
   pyspi_0.6.1-1.3_source

--- a/system/t05_snapshot/FilterSnapshot1Test_snapshot_show
+++ b/system/t05_snapshot/FilterSnapshot1Test_snapshot_show
@@ -1,6 +1,8 @@
 Name: snap2
 Description: Filtered 'snap1', query was: 'mame unrar'
 Number of packages: 4
+Sources:
+  snap1 [snapshot]
 Packages:
   mame_0.146-5_amd64
   unrar_1:4.1.4-1_amd64

--- a/system/t05_snapshot/FilterSnapshot2Test_snapshot_show
+++ b/system/t05_snapshot/FilterSnapshot2Test_snapshot_show
@@ -1,6 +1,8 @@
 Name: snap2
 Description: Filtered 'snap1', query was: 'rsyslog (>= 7.4.4)'
 Number of packages: 9
+Sources:
+  snap1 [snapshot]
 Packages:
   init-system-helpers_1.18~bpo70+1_all
   libestr0_0.1.9-1~bpo70+1_amd64

--- a/system/t05_snapshot/FilterSnapshot3Test_snapshot_show
+++ b/system/t05_snapshot/FilterSnapshot3Test_snapshot_show
@@ -1,6 +1,8 @@
 Name: snap2
 Description: Filtered 'snap1', query was: 'Priority (required) nginx xyz'
 Number of packages: 123
+Sources:
+  snap1 [snapshot]
 Packages:
   debconf_1.5.49_all
   debconf-i18n_1.5.49_all

--- a/system/t05_snapshot/FilterSnapshot7Test_snapshot_show
+++ b/system/t05_snapshot/FilterSnapshot7Test_snapshot_show
@@ -1,6 +1,8 @@
 Name: snap2
 Description: Filtered 'snap1', query was: 'rsyslog (>= 7.4.4), $Architecture (i386)'
 Number of packages: 10
+Sources:
+  snap1 [snapshot]
 Packages:
   init-system-helpers_1.18~bpo70+1_all
   libestr0_0.1.9-1~bpo70+1_i386

--- a/system/t05_snapshot/MergeSnapshot1Test_snapshot_show
+++ b/system/t05_snapshot/MergeSnapshot1Test_snapshot_show
@@ -2,6 +2,9 @@ Name: snap3
 Created At: 2014-06-29 02:23:49 MSK
 Description: Merged from sources: 'snap1', 'snap2'
 Number of packages: 56782
+Sources:
+  snap1 [snapshot]
+  snap2 [snapshot]
 Packages:
   0ad-data_0~r11863-1_all
   2ping_2.0-1_all

--- a/system/t05_snapshot/MergeSnapshot3Test_snapshot_show
+++ b/system/t05_snapshot/MergeSnapshot3Test_snapshot_show
@@ -2,6 +2,10 @@ Name: snap4
 Created At: 2014-06-29 02:14:26 MSK
 Description: Merged from sources: 'snap1', 'snap2', 'snap3'
 Number of packages: 58968
+Sources:
+  snap1 [snapshot]
+  snap2 [snapshot]
+  snap3 [snapshot]
 Packages:
   0ad-data_0.0.16-1~bpo70+1_all
   0ad-data-common_0.0.16-1~bpo70+1_all

--- a/system/t05_snapshot/MergeSnapshot6Test_snapshot_show
+++ b/system/t05_snapshot/MergeSnapshot6Test_snapshot_show
@@ -2,6 +2,10 @@ Name: snap4
 Created At: 2014-06-29 02:15:01 MSK
 Description: Merged from sources: 'snap1', 'snap2', 'snap3'
 Number of packages: 58802
+Sources:
+  snap1 [snapshot]
+  snap2 [snapshot]
+  snap3 [snapshot]
 Packages:
   0ad-data_0.0.16-1~bpo70+1_all
   0ad-data-common_0.0.16-1~bpo70+1_all

--- a/system/t05_snapshot/MergeSnapshot7Test_snapshot_show
+++ b/system/t05_snapshot/MergeSnapshot7Test_snapshot_show
@@ -2,6 +2,10 @@ Name: snap4
 Created At: 2014-06-29 02:16:12 MSK
 Description: Merged from sources: 'snap3', 'snap2', 'snap1'
 Number of packages: 58817
+Sources:
+  snap3 [snapshot]
+  snap2 [snapshot]
+  snap1 [snapshot]
 Packages:
   0ad-data_0~r11863-1_all
   0ad-data-common_0.0.16-1~bpo70+1_all

--- a/system/t05_snapshot/MergeSnapshot9Test_snapshot_show
+++ b/system/t05_snapshot/MergeSnapshot9Test_snapshot_show
@@ -2,6 +2,10 @@ Name: snap4
 Created At: 2014-06-29 02:19:14 MSK
 Description: Merged from sources: 'snap1', 'snap2', 'snap3'
 Number of packages: 61524
+Sources:
+  snap1 [snapshot]
+  snap2 [snapshot]
+  snap3 [snapshot]
 Packages:
   0ad-data_0.0.16-1~bpo70+1_all
   0ad-data_0~r11863-1_all

--- a/system/t05_snapshot/PullSnapshot10Test_snapshot_show
+++ b/system/t05_snapshot/PullSnapshot10Test_snapshot_show
@@ -2,6 +2,9 @@ Name: snap3
 Created At: 2014-06-29 02:00:49 MSK
 Description: Pulled into 'snap1' with 'snap2' as source, pull request was: 'rsyslog (>= 7.4.4)'
 Number of packages: 73295
+Sources:
+  snap1 [snapshot]
+  snap2 [snapshot]
 Packages:
   0ad-data_0~r11863-1_all
   2ping_2.0-1_all

--- a/system/t05_snapshot/PullSnapshot11Test_snapshot_show
+++ b/system/t05_snapshot/PullSnapshot11Test_snapshot_show
@@ -2,6 +2,9 @@ Name: snap3
 Created At: 2014-06-29 02:03:59 MSK
 Description: Pulled into 'snap1' with 'snap2' as source, pull request was: 'rsyslog (>= 7.4.4)'
 Number of packages: 56130
+Sources:
+  snap1 [snapshot]
+  snap2 [snapshot]
 Packages:
   0ad-data_0~r11863-1_all
   2ping_2.0-1_all

--- a/system/t05_snapshot/PullSnapshot1Test_snapshot_show
+++ b/system/t05_snapshot/PullSnapshot1Test_snapshot_show
@@ -2,6 +2,9 @@ Name: snap3
 Created At: 2014-06-29 02:31:20 MSK
 Description: Pulled into 'snap1' with 'snap2' as source, pull request was: 'mame unrar'
 Number of packages: 56125
+Sources:
+  snap1 [snapshot]
+  snap2 [snapshot]
 Packages:
   0ad-data_0~r11863-1_all
   2ping_2.0-1_all

--- a/system/t05_snapshot/PullSnapshot2Test_snapshot_show
+++ b/system/t05_snapshot/PullSnapshot2Test_snapshot_show
@@ -2,6 +2,9 @@ Name: snap3
 Created At: 2014-06-29 01:50:10 MSK
 Description: Pulled into 'snap1' with 'snap2' as source, pull request was: 'rsyslog (>= 7.4.4)'
 Number of packages: 56126
+Sources:
+  snap1 [snapshot]
+  snap2 [snapshot]
 Packages:
   0ad-data_0~r11863-1_all
   2ping_2.0-1_all

--- a/system/t05_snapshot/PullSnapshot3Test_snapshot_show
+++ b/system/t05_snapshot/PullSnapshot3Test_snapshot_show
@@ -2,6 +2,9 @@ Name: snap3
 Created At: 2014-06-29 01:52:15 MSK
 Description: Pulled into 'snap1' with 'snap2' as source, pull request was: 'rsyslog (>= 7.4.4)'
 Number of packages: 56121
+Sources:
+  snap1 [snapshot]
+  snap2 [snapshot]
 Packages:
   0ad-data_0~r11863-1_all
   2ping_2.0-1_all

--- a/system/t05_snapshot/PullSnapshot8Test_snapshot_show
+++ b/system/t05_snapshot/PullSnapshot8Test_snapshot_show
@@ -2,6 +2,9 @@ Name: snap3
 Created At: 2014-06-29 01:57:44 MSK
 Description: Pulled into 'snap1' with 'snap2' as source, pull request was: 'lunar-landing mars-landing (>= 1.0)'
 Number of packages: 56121
+Sources:
+  snap1 [snapshot]
+  snap2 [snapshot]
 Packages:
   0ad-data_0~r11863-1_all
   2ping_2.0-1_all

--- a/system/t05_snapshot/PullSnapshot9Test_snapshot_show
+++ b/system/t05_snapshot/PullSnapshot9Test_snapshot_show
@@ -2,6 +2,9 @@ Name: snap3
 Created At: 2014-06-29 01:58:24 MSK
 Description: Pulled into 'snap1' with 'snap2' as source, pull request was: 'rsyslog (>= 7.4.4)'
 Number of packages: 56131
+Sources:
+  snap1 [snapshot]
+  snap2 [snapshot]
 Packages:
   0ad-data_0~r11863-1_all
   2ping_2.0-1_all

--- a/system/t05_snapshot/ShowSnapshot1Test_gold
+++ b/system/t05_snapshot/ShowSnapshot1Test_gold
@@ -2,6 +2,8 @@ Name: snap1
 Created At: 2014-06-28 03:01:02 MSK
 Description: Snapshot from mirror [wheezy-non-free]: http://mirror.yandex.ru/debian/ wheezy
 Number of packages: 661
+Sources:
+  wheezy-non-free [repo]
 Packages:
   abs-guide_6.5-1_all
   album_4.06-2_all

--- a/system/t05_snapshot/ShowSnapshot3Test_gold
+++ b/system/t05_snapshot/ShowSnapshot3Test_gold
@@ -2,3 +2,5 @@ Name: snap1
 Created At: 2014-01-24 13:06:43 MSK
 Description: Snapshot from mirror [wheezy-non-free]: http://mirror.yandex.ru/debian/ wheezy
 Number of packages: 661
+Sources:
+  wheezy-non-free [repo]

--- a/system/t06_publish/PublishShow1Test_gold
+++ b/system/t06_publish/PublishShow1Test_gold
@@ -1,0 +1,5 @@
+Prefix: .
+Distribution: maverick
+Architectures: amd64 i386
+Sources:
+  main: snap1 [snapshot]

--- a/system/t06_publish/PublishShow2Test_gold
+++ b/system/t06_publish/PublishShow2Test_gold
@@ -1,0 +1,5 @@
+Prefix: ppa/smira
+Distribution: maverick
+Architectures: amd64 i386
+Sources:
+  main: snap1 [snapshot]

--- a/system/t06_publish/__init__.py
+++ b/system/t06_publish/__init__.py
@@ -3,6 +3,7 @@ Testing publishing snapshots
 """
 
 from .drop import *
+from .show import *
 from .list import *
 from .repo import *
 from .snapshot import *

--- a/system/t06_publish/show.py
+++ b/system/t06_publish/show.py
@@ -1,0 +1,27 @@
+from lib import BaseTest
+
+
+class PublishShow1Test(BaseTest):
+    """
+    publish show: existing snapshot
+    """
+    fixtureDB = True
+    fixturePool = True
+    fixtureCmds = [
+        "aptly snapshot create snap1 from mirror gnuplot-maverick",
+        "aptly publish snapshot -keyring=${files}/aptly.pub -secret-keyring=${files}/aptly.sec snap1",
+    ]
+    runCmd = "aptly publish show maverick"
+
+
+class PublishShow2Test(BaseTest):
+    """
+    publish show: under prefix
+    """
+    fixtureDB = True
+    fixturePool = True
+    fixtureCmds = [
+        "aptly snapshot create snap1 from mirror gnuplot-maverick",
+        "aptly publish snapshot -keyring=${files}/aptly.pub -secret-keyring=${files}/aptly.sec snap1 ppa/smira",
+    ]
+    runCmd = "aptly publish show maverick ppa/smira"


### PR DESCRIPTION
## Description of the Change

For aptly wrapper tools to work such as [pyaptly](https://github.com/adfinis-sygroup/pyaptly) it needs to know sources of a snapshots and published repositories.
Such details are currently part of the description. However such description is hard to parse (or also to read for humans compare aptly publish list) and not always applicable (e.g. when a snapshot has been renamed, merged etc.).

Hence it would be good to have a Sources printed in the snapshot show command and have an additional command publish show to show details of a published repository as well.

Such details may also be very helpful for command line users to get a clue what has been done.

## Checklist

- [x] functional test added/updated (if change is functional)
- [x] man page updated (if applicable)
- [x] documentation updated
- [x] author name in `AUTHORS`
