### PR TITLE
Allow requesting the unrendered dot graph from the graph endpoint

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,3 +22,4 @@ List of contributors, in chronological order:
 * Phil Frost (https://github.com/bitglue)
 * Benoit Foucher (https://github.com/bentoi)
 * Geoffrey Thomas (https://github.com/geofft)
+* Harald Sitter (https://github.com/apachelogger)

--- a/api/graph.go
+++ b/api/graph.go
@@ -39,6 +39,13 @@ func apiGraph(c *gin.Context) {
 
 	buf := bytes.NewBufferString(graph.String())
 
+	if ext == "dot" || ext == "gv" {
+		// If the raw dot data is requested, return it as string.
+		// This allows client-side rendering rather than server-side.
+		c.String(200, buf.String())
+		return
+	}
+
 	command := exec.Command("dot", "-T"+ext)
 	command.Stderr = os.Stderr
 

--- a/system/t12_api/graph.py
+++ b/system/t12_api/graph.py
@@ -15,3 +15,7 @@ class GraphAPITest(APITest):
         resp = self.get("/api/graph.svg")
         self.check_equal(resp.headers["Content-Type"], "image/svg+xml")
         self.check_equal(resp.content[:4], '<?xm')
+
+        resp = self.get("/api/graph.dot")
+        self.check_equal(resp.headers["Content-Type"], "text/plain; charset=utf-8")
+        self.check_equal(resp.content[:13], 'digraph aptly')


### PR DESCRIPTION
When api/graph.{dot,gv} is requested the raw string for dot gets returned.
This allows client-side rendering rather than server-side. It also makes
the optional dependency on graphivz for dot unnecessary to use the graph
endpoint.
