### PR TITLE
Support a vertical graph layout in addition to the existing horizontal

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,3 +22,4 @@ List of contributors, in chronological order:
 * Phil Frost (https://github.com/bitglue)
 * Benoit Foucher (https://github.com/bentoi)
 * Geoffrey Thomas (https://github.com/geofft)
+* Johannes Layher (https://github.com/jola5)

--- a/api/graph.go
+++ b/api/graph.go
@@ -11,14 +11,20 @@ import (
 	"os/exec"
 )
 
-// GET /api/graph.:ext
+// GET /api/graph.:ext/:vertical
 func apiGraph(c *gin.Context) {
 	var (
 		err    error
 		output []byte
+		vertical bool = false
 	)
 
 	ext := c.Params.ByName("ext")
+
+	// TODO: api is untested!
+	if c.Params.ByName("vertical") == "vertical" {
+		vertical = true
+	}
 
 	factory := context.CollectionFactory()
 
@@ -31,7 +37,7 @@ func apiGraph(c *gin.Context) {
 	factory.PublishedRepoCollection().RLock()
 	defer factory.PublishedRepoCollection().RUnlock()
 
-	graph, err := deb.BuildGraph(factory)
+	graph, err := deb.BuildGraph(factory, vertical)
 	if err != nil {
 		c.JSON(500, err)
 		return

--- a/api/graph.go
+++ b/api/graph.go
@@ -11,20 +11,16 @@ import (
 	"os/exec"
 )
 
-// GET /api/graph.:ext/:vertical
+// GET /api/graph.:ext?layout=[vertical|horizontal(default)]
 func apiGraph(c *gin.Context) {
 	var (
 		err    error
 		output []byte
-		vertical bool = false
 	)
 
 	ext := c.Params.ByName("ext")
-
-	// TODO: api is untested!
-	if c.Params.ByName("vertical") == "vertical" {
-		vertical = true
-	}
+	layout := c.Request.URL.Query().Get("layout")
+	fmt.Printf("Layout is: "+layout)
 
 	factory := context.CollectionFactory()
 
@@ -37,7 +33,7 @@ func apiGraph(c *gin.Context) {
 	factory.PublishedRepoCollection().RLock()
 	defer factory.PublishedRepoCollection().RUnlock()
 
-	graph, err := deb.BuildGraph(factory, vertical)
+	graph, err := deb.BuildGraph(factory, layout)
 	if err != nil {
 		c.JSON(500, err)
 		return

--- a/api/graph.go
+++ b/api/graph.go
@@ -20,7 +20,6 @@ func apiGraph(c *gin.Context) {
 
 	ext := c.Params.ByName("ext")
 	layout := c.Request.URL.Query().Get("layout")
-	fmt.Printf("Layout is: "+layout)
 
 	factory := context.CollectionFactory()
 

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -21,8 +21,11 @@ func aptlyGraph(cmd *commander.Command, args []string) error {
 		return commander.ErrCommandError
 	}
 
+	vertical := context.Flags().Lookup("vertical").Value.Get().(bool)
+
 	fmt.Printf("Generating graph...\n")
-	graph, err := deb.BuildGraph(context.CollectionFactory())
+	graph, err := deb.BuildGraph(context.CollectionFactory(), vertical)
+
 	if err != nil {
 		return err
 	}
@@ -108,6 +111,7 @@ Example:
 
 	cmd.Flag.String("format", "png", "render graph to specified format (png, svg, pdf, etc.)")
 	cmd.Flag.String("output", "", "specify output filename, default is to open result in viewer")
+	cmd.Flag.Bool("vertical", false, "try to achieve a more vertical graph layout")
 
 	return cmd
 }

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -21,10 +21,10 @@ func aptlyGraph(cmd *commander.Command, args []string) error {
 		return commander.ErrCommandError
 	}
 
-	vertical := context.Flags().Lookup("vertical").Value.Get().(bool)
+	layout := context.Flags().Lookup("layout").Value.String()
 
 	fmt.Printf("Generating graph...\n")
-	graph, err := deb.BuildGraph(context.CollectionFactory(), vertical)
+	graph, err := deb.BuildGraph(context.CollectionFactory(), layout)
 
 	if err != nil {
 		return err
@@ -111,7 +111,7 @@ Example:
 
 	cmd.Flag.String("format", "png", "render graph to specified format (png, svg, pdf, etc.)")
 	cmd.Flag.String("output", "", "specify output filename, default is to open result in viewer")
-	cmd.Flag.Bool("vertical", false, "try to achieve a more vertical graph layout")
+	cmd.Flag.String("layout", "horizontal", "create a more 'vertical' or a more 'horizontal' graph layout")
 
 	return cmd
 }

--- a/deb/graph.go
+++ b/deb/graph.go
@@ -87,7 +87,7 @@ func BuildGraph(collectionFactory *CollectionFactory, layout string) (gographviz
 
 		description := snapshot.Description
 		if snapshot.SourceKind == "repo" {
-			description = "Snapshot from repo\n"
+			description = "Snapshot from repo"
 		}
 
 		graph.AddNode("aptly", snapshot.UUID, map[string]string{

--- a/deb/graph.go
+++ b/deb/graph.go
@@ -7,7 +7,7 @@ import (
 )
 
 // BuildGraph generates graph contents from aptly object database
-func BuildGraph(collectionFactory *CollectionFactory, vertical bool) (gographviz.Interface, error) {
+func BuildGraph(collectionFactory *CollectionFactory, layout string) (gographviz.Interface, error) {
 	var err error
 
 	graph := gographviz.NewEscape()
@@ -17,14 +17,16 @@ func BuildGraph(collectionFactory *CollectionFactory, vertical bool) (gographviz
 	var labelStart string
 	var labelEnd string
 
-	if vertical {
-		graph.AddAttr("aptly", "rankdir", "LR")
-		labelStart = ""
-		labelEnd = ""
-	} else {
-		graph.AddAttr("aptly", "rankdir", "TB")
-		labelStart = "{"
-		labelEnd = "}"
+	switch layout {
+		case "vertical":
+			graph.AddAttr("aptly", "rankdir", "LR")
+			labelStart = ""
+			labelEnd = ""
+		case "horizontal":
+			fallthrough
+		default:
+			labelStart = "{"
+			labelEnd = "}"
 	}
 
 	existingNodes := map[string]bool{}

--- a/system/lib.py
+++ b/system/lib.py
@@ -270,6 +270,14 @@ class BaseTest(object):
         if a != b:
             self.verify_match(a, b, match_prepare=pprint.pformat)
 
+    def check_ge(self, a, b):
+        if not a >= b:
+            raise Exception("%s is not greater or equal to %s" % (a, b))
+
+    def check_gt(self, a, b):
+        if not a > b:
+            raise Exception("%s is not greater to %s" % (a, b))
+
     def check_in(self, item, l):
         if not item in l:
             raise Exception("item %r not in %r", item, l)

--- a/system/t12_api/graph.py
+++ b/system/t12_api/graph.py
@@ -31,5 +31,5 @@ class GraphAPITest(APITest):
         svgVWidth = ET.fromstring(vertical).get('width').replace("pt","")
         svgVHeight = ET.fromstring(vertical).get('height').replace("pt","")
 
-        self.check_gt(svgHWidth, svgVWidth)
-        self.check_gt(svgVHeight, svgHHeight)
+        #self.check_gt(svgHWidth, svgVWidth)
+        #self.check_gt(svgVHeight, svgHHeight)

--- a/system/t12_api/graph.py
+++ b/system/t12_api/graph.py
@@ -1,4 +1,5 @@
 from api_lib import APITest
+import xml.etree.ElementTree as ET
 
 
 class GraphAPITest(APITest):
@@ -15,3 +16,20 @@ class GraphAPITest(APITest):
         resp = self.get("/api/graph.svg")
         self.check_equal(resp.headers["Content-Type"], "image/svg+xml")
         self.check_equal(resp.content[:4], '<?xm')
+
+        # make sure our default layout is horizontal
+        default = self.get("/api/graph.svg").content
+        horizontal = self.get("/api/graph.svg?layout=horizontal").content
+        self.check_equal(default, horizontal)
+
+        # basic test of layout:
+        # horizontal should be wider than vertical
+        # vertical should be higher than horizontal
+        vertical = self.get("/api/graph.svg?layout=vertical").content
+        svgHWidth = ET.fromstring(horizontal).get('width').replace("pt","")
+        svgHHeight = ET.fromstring(horizontal).get('height').replace("pt","")
+        svgVWidth = ET.fromstring(vertical).get('width').replace("pt","")
+        svgVHeight = ET.fromstring(vertical).get('height').replace("pt","")
+
+        self.check_gt(svgHWidth, svgVWidth)
+        self.check_gt(svgVHeight, svgHHeight)

--- a/system/t12_api/graph.py
+++ b/system/t12_api/graph.py
@@ -21,19 +21,27 @@ class GraphAPITest(APITest):
         self.check_equal(resp.headers["Content-Type"], "text/plain; charset=utf-8")
         self.check_equal(resp.content[:13], 'digraph aptly')
 
-        # make sure our default layout is horizontal
-        default = self.get("/api/graph.svg").content
-        horizontal = self.get("/api/graph.svg?layout=horizontal").content
-        self.check_equal(default, horizontal)
-
         # basic test of layout:
-        # horizontal should be wider than vertical
-        # vertical should be higher than horizontal
-        vertical = self.get("/api/graph.svg?layout=vertical").content
-        svgHWidth = ET.fromstring(horizontal).get('width').replace("pt","")
-        svgHHeight = ET.fromstring(horizontal).get('height').replace("pt","")
-        svgVWidth = ET.fromstring(vertical).get('width').replace("pt","")
-        svgVHeight = ET.fromstring(vertical).get('height').replace("pt","")
+        #   horizontal should be wider than vertical
+        #   vertical should be higher than horizontal
+        # for this to work we need at couple of repos
+        tempRepos = [self.random_name() for r in range(3)]
+        for repo in tempRepos:
+            self.check_equal(self.post("/api/repos", json={"Name": repo, "Comment": "graph test repo"}).status_code, 201)
 
-        #self.check_gt(svgHWidth, svgVWidth)
-        #self.check_gt(svgVHeight, svgHHeight)
+        horizontal = self.get("/api/graph.svg?layout=horizontal").content
+        vertical = self.get("/api/graph.svg?layout=vertical").content
+        horizontalWidth = int(ET.fromstring(horizontal).get('width').replace("pt",""))
+        horizontalHeight = int(ET.fromstring(horizontal).get('height').replace("pt",""))
+        verticalWidth = int(ET.fromstring(vertical).get('width').replace("pt",""))
+        verticalHeight = int(ET.fromstring(vertical).get('height').replace("pt",""))
+
+        self.check_gt(horizontalWidth, verticalWidth)
+        self.check_gt(verticalHeight, horizontalHeight)
+
+        # make sure our default layout is horizontal
+        self.check_equal(horizontal, self.get("/api/graph.svg").content)
+
+        # remove the repos again
+        for repo in tempRepos:
+            self.check_equal(self.delete("/api/repos/" + repo, params={"force": "1"}).status_code, 200)


### PR DESCRIPTION
## Requirements
[![Build Status](https://travis-ci.org/jola5/aptly.svg?branch=master)](https://travis-ci.org/jola5/aptly)

## Description of the Change
The default layout of graphviz tends to result in very wide graphs for environments with a lot of repositories. Optionally changing graphviz's rankdir results in a more vertical layout which may be preferable in some cases. In using `layout=horizontal` as default this change is fully backwards compatible. 

I decided to use a generic `layout` switch over a simpler `vertical=false` argument. Maybe someone fancies to implement some of graphviz's more sophisticated layouts like radial. 

### horizontal layout (default)
`aptly graph`
`aptly graph -layout=horizontal`
`http://localhost:8080/api/graph.png`
`http://localhost:8080/api/graph.png?layout=horizontal`
![](http://i.imgur.com/LVUQvPA.png)

### vertical layout (new)
`aptly graph -layout=vertical`
`http://localhost:8080/api/graph.png?layout=vertical`
![](http://i.imgur.com/hztFWOE.png)

## Checklist
- [ ] unit-test added (if change is algorithm)
- [x] functional test added/updated (if change is functional)
- [x] man page updated (if applicable)
- [x] documentation updated
- [x] author name in `AUTHORS`
