### PR TITLE
Abort serve command if rootDir is inaccessible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ before_install:
   - mkdir -p $GOPATH/src/github.com/smira
   - ln -s $TRAVIS_BUILD_DIR $GOPATH/src/github.com/smira || true
   - cd $GOPATH/src/github.com/smira/aptly
-  - go get golang.org/x/sys/unix
 install:
   - make prepare
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_install:
   - mkdir -p $GOPATH/src/github.com/smira
   - ln -s $TRAVIS_BUILD_DIR $GOPATH/src/github.com/smira || true
   - cd $GOPATH/src/github.com/smira/aptly
+  - go get golang.org/x/sys/unix
 install:
   - make prepare
 

--- a/Gomfile
+++ b/Gomfile
@@ -26,6 +26,7 @@ gom 'github.com/ugorji/go/codec', :commit => '71c2886f5a673a35f909803f38ece58101
 gom 'github.com/vaughan0/go-ini', :commit => 'a98ad7ee00ec53921f08832bc06ecf7fd600e6a1'
 gom 'github.com/wsxiaoys/terminal/color', :commit => '5668e431776a7957528361f90ce828266c69ed08'
 gom 'golang.org/x/crypto/ssh/terminal', :commit => 'a7ead6ddf06233883deca151dffaef2effbf498f'
+gom 'golang.org/x/sys/unix', :commit => '7a6e5648d140666db5d920909e082ca00a87ba2c'
 
 group :test do
     gom 'gopkg.in/check.v1'

--- a/cmd/api_serve.go
+++ b/cmd/api_serve.go
@@ -3,11 +3,10 @@ package cmd
 import (
 	"fmt"
 	"github.com/smira/aptly/api"
+	"github.com/smira/aptly/utils"
 	"github.com/smira/commander"
 	"github.com/smira/flag"
 	"net/http"
-	"os"
-	"golang.org/x/sys/unix"
 )
 
 func aptlyAPIServe(cmd *commander.Command, args []string) error {
@@ -26,16 +25,9 @@ func aptlyAPIServe(cmd *commander.Command, args []string) error {
 	// anything else must fail.
 	// E.g.: Running the service under a different user may lead to a rootDir
 	// that exists but is not usable due to access permissions.
-	// Config loads and returns current configuration
-	_, err = os.Stat(context.Config().RootDir);
+	err = utils.DirIsAccessible(context.Config().RootDir)
 	if err != nil {
-		if ! os.IsNotExist(err) {
-			return fmt.Errorf("Something went wrong, %v", err)
-		}
-	} else {
-		if unix.Access(context.Config().RootDir, unix.W_OK) != nil {
-			return fmt.Errorf("Configured rootDir '%s' is inaccessible, check access rights", context.Config().RootDir)
-		}
+		return err
 	}
 
 	listen := context.Flags().Lookup("listen").Value.String()

--- a/cmd/api_serve.go
+++ b/cmd/api_serve.go
@@ -6,6 +6,7 @@ import (
 	"github.com/smira/commander"
 	"github.com/smira/flag"
 	"net/http"
+	"golang.org/x/sys/unix"
 )
 
 func aptlyAPIServe(cmd *commander.Command, args []string) error {
@@ -16,6 +17,10 @@ func aptlyAPIServe(cmd *commander.Command, args []string) error {
 	if len(args) != 0 {
 		cmd.Usage()
 		return commander.ErrCommandError
+	}
+
+	if unix.Access(context.Config().RootDir, unix.W_OK) != nil {
+		return fmt.Errorf("Configured rootDir '%s' inaccesible, check access rights", context.Config().RootDir)
 	}
 
 	listen := context.Flags().Lookup("listen").Value.String()

--- a/cmd/api_serve.go
+++ b/cmd/api_serve.go
@@ -20,7 +20,7 @@ func aptlyAPIServe(cmd *commander.Command, args []string) error {
 	}
 
 	if unix.Access(context.Config().RootDir, unix.W_OK) != nil {
-		return fmt.Errorf("Configured rootDir '%s' inaccesible, check access rights", context.Config().RootDir)
+		return fmt.Errorf("Configured rootDir '%s' is inaccessible, check access rights", context.Config().RootDir)
 	}
 
 	listen := context.Flags().Lookup("listen").Value.String()

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -24,7 +24,7 @@ func aptlyServe(cmd *commander.Command, args []string) error {
 	}
 
 	if unix.Access(context.Config().RootDir, unix.W_OK) != nil {
-		return fmt.Errorf("Configured rootDir '%s' inaccesible, check access rights", context.Config().RootDir)
+		return fmt.Errorf("Configured rootDir '%s' is inaccessible, check access rights", context.Config().RootDir)
 	}
 
 	if context.CollectionFactory().PublishedRepoCollection().Len() == 0 {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -23,8 +23,22 @@ func aptlyServe(cmd *commander.Command, args []string) error {
 		return commander.ErrCommandError
 	}
 
-	if unix.Access(context.Config().RootDir, unix.W_OK) != nil {
-		return fmt.Errorf("Configured rootDir '%s' is inaccessible, check access rights", context.Config().RootDir)
+	// There are only two working options for aptly's rootDir:
+	//   1. rootDir does not exist, then we'll create it
+	//   2. rootDir exists and is writable
+	// anything else must fail.
+	// E.g.: Running the service under a different user may lead to a rootDir
+	// that exists but is not usable due to access permissions.
+	// Config loads and returns current configuration
+	_, err = os.Stat(context.Config().RootDir);
+	if err != nil {
+		if ! os.IsNotExist(err) {
+			return fmt.Errorf("Something went wrong, %v", err)
+		}
+	} else {
+		if unix.Access(context.Config().RootDir, unix.W_OK) != nil {
+			return fmt.Errorf("Configured rootDir '%s' is inaccessible, check access rights", context.Config().RootDir)
+		}
 	}
 
 	if context.CollectionFactory().PublishedRepoCollection().Len() == 0 {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"golang.org/x/sys/unix"
 )
 
 func aptlyServe(cmd *commander.Command, args []string) error {
@@ -20,6 +21,10 @@ func aptlyServe(cmd *commander.Command, args []string) error {
 	if len(args) != 0 {
 		cmd.Usage()
 		return commander.ErrCommandError
+	}
+
+	if unix.Access(context.Config().RootDir, unix.W_OK) != nil {
+		return fmt.Errorf("Configured rootDir '%s' inaccesible, check access rights", context.Config().RootDir)
 	}
 
 	if context.CollectionFactory().PublishedRepoCollection().Len() == 0 {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"sort"
 	"strings"
-	"golang.org/x/sys/unix"
 )
 
 func aptlyServe(cmd *commander.Command, args []string) error {
@@ -29,16 +28,9 @@ func aptlyServe(cmd *commander.Command, args []string) error {
 	// anything else must fail.
 	// E.g.: Running the service under a different user may lead to a rootDir
 	// that exists but is not usable due to access permissions.
-	// Config loads and returns current configuration
-	_, err = os.Stat(context.Config().RootDir);
+	err = utils.DirIsAccessible(context.Config().RootDir)
 	if err != nil {
-		if ! os.IsNotExist(err) {
-			return fmt.Errorf("Something went wrong, %v", err)
-		}
-	} else {
-		if unix.Access(context.Config().RootDir, unix.W_OK) != nil {
-			return fmt.Errorf("Configured rootDir '%s' is inaccessible, check access rights", context.Config().RootDir)
-		}
+		return err
 	}
 
 	if context.CollectionFactory().PublishedRepoCollection().Len() == 0 {

--- a/system/t07_serve/RootDirInaccessible_gold
+++ b/system/t07_serve/RootDirInaccessible_gold
@@ -1,0 +1,1 @@
+ERROR: Configured rootDir '/rootDir/does/not/exist' is inaccessible, check access rights

--- a/system/t07_serve/RootDirInaccessible_gold
+++ b/system/t07_serve/RootDirInaccessible_gold
@@ -1,1 +1,1 @@
-ERROR: Configured rootDir '/rootDir/does/not/exist' is inaccessible, check access rights
+ERROR: Configured rootDir '/root' is inaccessible, check access rights

--- a/system/t07_serve/RootDirInaccessible_gold
+++ b/system/t07_serve/RootDirInaccessible_gold
@@ -1,1 +1,1 @@
-ERROR: Configured rootDir '/root' is inaccessible, check access rights
+ERROR: '/root' is inaccessible, check access rights

--- a/system/t07_serve/__init__.py
+++ b/system/t07_serve/__init__.py
@@ -23,29 +23,9 @@ class RootDirInaccessible(BaseTest):
     configOverride = {
         "rootDir": "/root" # any directory that exists but is not writable
     }
+
     runCmd = "aptly serve -listen=127.0.0.1:8765"
-
-    def run(self):
-        try:
-            proc = subprocess.Popen(shlex.split(self.runCmd), stderr=subprocess.STDOUT, stdout=subprocess.PIPE, bufsize=0)
-            time.sleep(1)
-
-            conn = httplib.HTTPConnection("127.0.0.1", 8765)
-            conn.request("GET", "/")
-            r = conn.getresponse()
-            self.http_response = r.read()
-            output = os.read(proc.stdout.fileno(), 8192)
-
-        except socket_error as serr:
-            if serr.errno != errno.ECONNREFUSED:
-                raise serr
-
-        finally:
-            self.output, err = proc.communicate()
-
-    def check(self):
-        self.check_output()
-
+    expectedCode = 1
 
 class Serve1Test(BaseTest):
     """

--- a/system/t07_serve/__init__.py
+++ b/system/t07_serve/__init__.py
@@ -19,7 +19,10 @@ class RootDirInaccessible(BaseTest):
     """
     fixtureDB = False
     fixturePool = False
-    configOverride = { "rootDir": "/rootDir/does/not/exist" }
+
+    configOverride = {
+        "rootDir": "/root" # any directory that exists but is not writable
+    }
     runCmd = "aptly serve -listen=127.0.0.1:8765"
 
     def run(self):

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,2 +1,23 @@
 // Package utils collects various services: simple operations, compression, etc.
 package utils
+
+import (
+  "fmt"
+  "os"
+  "golang.org/x/sys/unix"
+)
+
+// check if directory exists and is accessible
+func DirIsAccessible(filename string) error {
+  _, err := os.Stat(filename);
+  if err != nil {
+    if ! os.IsNotExist(err) {
+      return fmt.Errorf("Something went wrong, %v", err)
+    }
+  } else {
+    if unix.Access(filename, unix.W_OK) != nil {
+      return fmt.Errorf("'%s' is inaccessible, check access rights", filename)
+    }
+  }
+  return nil
+}


### PR DESCRIPTION
Fixes #467

## Requirements
[![Build Status](https://travis-ci.org/jola5/aptly.svg?branch=master)](https://travis-ci.org/jola5/aptly)
Tests added.

## Description of the Change
There are only two working options for aptly's rootDir:
1. rootDir does not exist, then we'll create it
2. rootDir exists and is writable

This PR ensures that if no. 2 fails `aptly serve` aborts immediately with a proper error message.

## Checklist

- [ ] unit-test added (if change is algorithm)
- [x] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] documentation updated
- [x] author name in `AUTHORS`
