### PR TITLE
support serving the API over unix domain socket

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - . env/bin/activate
   - pip install six packaging appdirs
   - pip install -U pip setuptools
-  - pip install boto requests python-swiftclient
+  - pip install boto requests requests-unixsocket python-swiftclient
   - mkdir -p $GOPATH/src/github.com/smira
   - ln -s $TRAVIS_BUILD_DIR $GOPATH/src/github.com/smira || true
   - cd $GOPATH/src/github.com/smira/aptly

--- a/man/aptly.1
+++ b/man/aptly.1
@@ -1685,20 +1685,17 @@ host:port for HTTP listening
 \fBaptly\fR \fBapi\fR \fBserve\fR
 .
 .P
-Stat HTTP server with aptly REST API\.
+Start HTTP server with aptly REST API\. The server can listen to either a port or Unix domain socket\. When using a socket, Aptly will fully manage the socket file\.
 .
 .P
-Example:
-.
-.P
-$ aptly api serve \-listen=:8080
+Example: $ aptly api serve \-listen=:8080 $ aptly api serve \-listen=unix:///tmp/aptly\.sock
 .
 .P
 Options:
 .
 .TP
 \-\fBlisten\fR=:8080
-host:port for HTTP listening
+host:port for HTTP listening or unix://path to listen on a Unix domain socket
 .
 .TP
 \-\fBno\-lock\fR=false
@@ -1881,6 +1878,9 @@ Harald Sitter (https://github\.com/apachelogger)
 .
 .IP "\[ci]" 4
 Johannes Layher (https://github\.com/jola5)
+.
+.IP "\[ci]" 4
+Charles Hsu (https://github\.com/charz)
 .
 .IP "" 0
 

--- a/system/t12_api/__init__.py
+++ b/system/t12_api/__init__.py
@@ -9,3 +9,4 @@ from .version import *
 from .graph import *
 from .snapshots import *
 from .packages import *
+from .unix_socket import *

--- a/system/t12_api/unix_socket.py
+++ b/system/t12_api/unix_socket.py
@@ -1,0 +1,36 @@
+import requests_unixsocket
+import time
+import urllib
+
+from lib import BaseTest
+
+class UnixSocketAPITest(BaseTest):
+    aptly_server = None
+    socket_path = "/tmp/_aptly_test.sock"
+    base_url = ("unix://%s" % socket_path)
+
+    def prepare(self):
+        if self.aptly_server is None:
+            self.aptly_server = self._start_process("aptly api serve -no-lock -listen=%s" % (self.base_url),)
+            time.sleep(1)
+        super(UnixSocketAPITest, self).prepare()
+
+    def shutdown(self):
+        if self.aptly_server is not None:
+            self.aptly_server.terminate()
+            self.aptly_server.wait()
+            self.aptly_server = None
+        super(UnixSocketAPITest, self).shutdown()
+
+    def run(self):
+        pass
+
+    """
+    Verify we can listen on a unix domain socket.
+    """
+    def check(self):
+        session = requests_unixsocket.Session()
+        r = session.get('http+unix://%s/api/version' % urllib.quote(UnixSocketAPITest.socket_path, safe=''))
+        # Just needs to come back, we actually don't care much about the code.
+        # Only needs to verify that the socket is actually responding.
+        self.check_equal(r.json(), {'Version': '0.9.8~dev'})


### PR DESCRIPTION
`unix://$PATH` as listen argument will bind aptly to a unix domain socket
rather than TCP.

This allows binding the API to a UDS rather than a port.
Since aptly has no concept of authentication or any amount of high level
API hardening one needs to bottle it up in some other manner. Binding
to a localhost port is often a step in the right direction, ultimately is
still a scary insecure setup as any user on that host getting compromised
would mean that the entire archive is compromised as well.
UDS on the other hand are basically files and have their access managed
by regular file permission. As such, binding to a socket is in fact
the least insecure way to listen as you'd have to explicitly open up the
socket permissions to an access qualified group. In the most conservative
scenario that means no one but the aptly user can talk to the API, in a
more practical setup apache might get access as well and proxy the UDS
with authentication or limited to GET operations.

Using UDS allows reducing the attack surface of the API server while
preserving all the flexibility.

Fixes #

## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

<!--

Why this change is important?

-->

## Checklist

- [x] unit-test added (if change is algorithm)
- [x] functional test added/updated (if change is functional)
- [x] man page updated (if applicable)
- [x] documentation updated
- [x] author name in `AUTHORS`
