### PR TITLE
fixes #331, include -dbgsym packages

### DIFF
--- a/deb/changes.go
+++ b/deb/changes.go
@@ -189,6 +189,9 @@ func (c *Changes) PackageQuery() (PackageQuery, error) {
 		binaryQuery = &AndQuery{
 			L: &NotQuery{Q: &FieldQuery{Field: "$PackageType", Relation: VersionEqual, Value: "source"}},
 			R: binaryQuery}
+		binaryQuery = &OrQuery{
+			L: &FieldQuery{Field: "Name", Relation: VersionPatternMatch, Value: "*-dbgsym"},
+			R: binaryQuery}
 	}
 
 	var nameQuery PackageQuery


### PR DESCRIPTION
dbgsym are the new automatic debug packages.
This is an extremely simple change to let these packages in