### PR TITLE
Implement new command `aptly repo create ... from snapshot ...`

### DIFF
--- a/man/aptly.1
+++ b/man/aptly.1
@@ -633,16 +633,22 @@ don\(cqt copy, just show what would be copied
 follow dependencies when processing package\-spec
 .
 .SH "CREATE LOCAL REPOSITORY"
-\fBaptly\fR \fBrepo\fR \fBcreate\fR \fIname\fR
+\fBaptly\fR \fBrepo\fR \fBcreate\fR \fIname\fR [ \fBfrom\fR \fBsnapshot\fR \fIsnapshot\fR ]
 .
 .P
 Create local package repository\. Repository would be empty when created, packages could be added from files, copied or moved from another local repository or imported from the mirror\.
+.
+.P
+If local package repository is created from snapshot, repo initial contents are copied from snapsot contents\.
 .
 .P
 Example:
 .
 .P
 $ aptly repo create testing
+.
+.P
+$ aptly repo create mysql35 from snapshot mysql\-35\-2017
 .
 .P
 Options:

--- a/system/t09_repo/CreateRepo7Test_gold
+++ b/system/t09_repo/CreateRepo7Test_gold
@@ -1,0 +1,3 @@
+
+Local repo [repo2] successfully added.
+You can run 'aptly repo add repo2 ...' to add packages to repository.

--- a/system/t09_repo/CreateRepo7Test_repo_show
+++ b/system/t09_repo/CreateRepo7Test_repo_show
@@ -1,0 +1,9 @@
+Name: repo2
+Comment: 
+Default Distribution: 
+Default Component: main
+Number of packages: 3
+Packages:
+  libboost-program-options-dev_1.49.0.1_i386
+  pyspi_0.6.1-1.3_source
+  pyspi_0.6.1-1.4_source

--- a/system/t09_repo/CreateRepo8Test_gold
+++ b/system/t09_repo/CreateRepo8Test_gold
@@ -1,0 +1,1 @@
+ERROR: unable to load source snapshot: snapshot with name snap-missing not found

--- a/system/t09_repo/create.py
+++ b/system/t09_repo/create.py
@@ -63,3 +63,27 @@ class CreateRepo6Test(BaseTest):
     runCmd = "aptly repo create -uploaders-file=${changes}/uploaders-not-found.json repo6"
     expectedCode = 1
     outputMatchPrepare = changesRemove
+
+
+class CreateRepo7Test(BaseTest):
+    """
+    create local repo: from snapshot
+    """
+    fixtureCmds = [
+        "aptly repo create repo1",
+        "aptly repo add repo1 ${files}",
+        "aptly snapshot create snap1 from repo repo1",
+    ]
+    runCmd = "aptly repo create repo2 from snapshot snap1"
+
+    def check(self):
+        self.check_output()
+        self.check_cmd_output("aptly repo show -with-packages repo2", "repo_show")
+
+
+class CreateRepo8Test(BaseTest):
+    """
+    create local repo: from missing snapshot
+    """
+    runCmd = "aptly repo create repo2 from snapshot snap-missing"
+    expectedCode = 1


### PR DESCRIPTION
Fixes #496

## Description of the Change

There's no way today to copy snapshot contents to local repo using CLI.

Implement that via simple extension to `aptly repo create` command to accept source snapshot name.

## Checklist

- [ ] unit-test added (if change is algorithm)
- [x] functional test added/updated (if change is functional)
- [x] man page updated (if applicable)
- [x] documentation updated
- [x] author name in `AUTHORS`
- [x] bash autocompletion updated (if change touches commands)