### PR TITLE
Bump Go AWS SDK to the latest version

### DIFF
--- a/Gomfile
+++ b/Gomfile
@@ -1,6 +1,6 @@
 gom 'github.com/AlekSi/pointer', :commit => '5f6d527dae3d678b46fbb20331ddf44e2b841943'
 gom 'github.com/awalterschulze/gographviz', :commit => '20d1f693416d9be045340150094aa42035a41c9e'
-gom 'github.com/aws/aws-sdk-go', :commit => 'a170e9cb76475a0da7c0326a13cc2b39e9244b3b'
+gom 'github.com/aws/aws-sdk-go', :commit => '2b26ad567f305510849d93c5d2025a8b561f2367'
 gom 'github.com/cheggaaa/pb', :commit => '2c1b74620cc58a81ac152ee2d322e28c806d81ed'
 gom 'github.com/DisposaBoy/JsonConfigReader', :commit => '33a99fdf1d5ee1f79b5077e9c06f955ad356d5f4'
 gom 'github.com/gin-gonic/gin', :commit => 'b1758d3bfa09e61ddbc1c9a627e936eec6a170de'


### PR DESCRIPTION
This seems to fix `NotImplemented` S3 error

