### PR TITLE
Configurable pool path hash

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,3 +26,4 @@ List of contributors, in chronological order:
 * Harald Sitter (https://github.com/apachelogger)
 * Johannes Layher (https://github.com/jola5)
 * Charles Hsu (https://github.com/charz)
+* TJ Merritt (https://github.com/tjmerritt)

--- a/aptly/interfaces.go
+++ b/aptly/interfaces.go
@@ -12,15 +12,19 @@ import (
 // PackagePool stores all the package files, deduplicating them.
 type PackagePool interface {
 	// Path returns full path to package file in pool given any name and hash of file contents
-	Path(filename string, hashMD5 string) (string, error)
-	// RelativePath returns path relative to pool's root for package files given MD5 and original filename
-	RelativePath(filename string, hashMD5 string) (string, error)
+	Path(filename string, hash string) (string, error)
+	// RelativePath returns path relative to pool's root for package files given hash and original filename
+	RelativePath(filename string, hash string) (string, error)
 	// FilepathList returns file paths of all the files in the pool
 	FilepathList(progress Progress) ([]string, error)
 	// Remove deletes file in package pool returns its size
 	Remove(path string) (size int64, err error)
 	// Import copies file into package pool
-	Import(path string, hashMD5 string) error
+	Import(path string, hash string) error
+	// Get name of hash to use for selecting file paths
+	HashSelector() string
+	// Set name of hash to use for selecting file paths
+	SetHashSelector(hashName string)
 }
 
 // PublishedStorage is abstraction of filesystem storing all published repositories

--- a/cmd/package_show.go
+++ b/cmd/package_show.go
@@ -88,7 +88,7 @@ func aptlyPackageShow(cmd *commander.Command, args []string) error {
 		if withFiles {
 			fmt.Printf("Files in the pool:\n")
 			for _, f := range p.Files() {
-				path, err := context.PackagePool().Path(f.Filename, f.Checksums.MD5)
+				path, err := context.PackagePool().Path(f.Filename, f.SelectChecksum(context.PackagePool().HashSelector()))
 				if err != nil {
 					return err
 				}

--- a/context/context.go
+++ b/context/context.go
@@ -300,6 +300,7 @@ func (context *AptlyContext) PackagePool() aptly.PackagePool {
 
 	if context.packagePool == nil {
 		context.packagePool = files.NewPackagePool(context.config().RootDir)
+		context.packagePool.SetHashSelector(context.config().HashSelector)
 	}
 
 	return context.packagePool

--- a/deb/import.go
+++ b/deb/import.go
@@ -127,7 +127,17 @@ func ImportPackageFiles(list *PackageList, packageFiles []string, forceReplace b
 			p.UpdateFiles([]PackageFile{{Filename: filepath.Base(file), Checksums: checksums}})
 		}
 
-		err = pool.Import(file, checksums.MD5)
+		checksum := checksums.MD5
+
+		if pool.HashSelector() == "SHA1" {
+			checksum = checksums.SHA1
+		} else if pool.HashSelector() == "SHA256" {
+			checksum = checksums.SHA256
+		} else if pool.HashSelector() == "SHA512" {
+			checksum = checksums.SHA512
+		}
+
+		err = pool.Import(file, checksum)
 		if err != nil {
 			reporter.Warning("Unable to import file %s into pool: %s", file, err)
 			failedFiles = append(failedFiles, file)
@@ -142,7 +152,7 @@ func ImportPackageFiles(list *PackageList, packageFiles []string, forceReplace b
 				continue
 			}
 			sourceFile := filepath.Join(filepath.Dir(file), filepath.Base(f.Filename))
-			err = pool.Import(sourceFile, f.Checksums.MD5)
+			err = pool.Import(sourceFile, f.SelectChecksum(pool.HashSelector()))
 			if err != nil {
 				reporter.Warning("Unable to import file %s into pool: %s", sourceFile, err)
 				failedFiles = append(failedFiles, file)

--- a/deb/package.go
+++ b/deb/package.go
@@ -417,7 +417,7 @@ func (p *Package) CalculateContents(packagePool aptly.PackagePool) []string {
 	}
 
 	file := p.Files()[0]
-	path, err := packagePool.Path(file.Filename, file.Checksums.MD5)
+	path, err := packagePool.Path(file.Filename, file.SelectChecksum(packagePool.HashSelector()))
 	if err != nil {
 		panic(err)
 	}
@@ -540,7 +540,7 @@ func (p *Package) LinkFromPool(publishedStorage aptly.PublishedStorage, packageP
 	}
 
 	for i, f := range p.Files() {
-		sourcePath, err := packagePool.Path(f.Filename, f.Checksums.MD5)
+		sourcePath, err := packagePool.Path(f.Filename, f.SelectChecksum(packagePool.HashSelector()))
 		if err != nil {
 			return err
 		}
@@ -600,7 +600,7 @@ func (p *Package) DownloadList(packagePool aptly.PackagePool) (result []PackageD
 	result = make([]PackageDownloadTask, 0, 1)
 
 	for _, f := range p.Files() {
-		poolPath, err := packagePool.Path(f.Filename, f.Checksums.MD5)
+		poolPath, err := packagePool.Path(f.Filename, f.SelectChecksum(packagePool.HashSelector()))
 		if err != nil {
 			return nil, err
 		}
@@ -638,7 +638,7 @@ func (p *Package) FilepathList(packagePool aptly.PackagePool) ([]string, error) 
 	result := make([]string, len(p.Files()))
 
 	for i, f := range p.Files() {
-		result[i], err = packagePool.RelativePath(f.Filename, f.Checksums.MD5)
+		result[i], err = packagePool.RelativePath(f.Filename, f.SelectChecksum(packagePool.HashSelector()))
 		if err != nil {
 			return nil, err
 		}

--- a/deb/package_files.go
+++ b/deb/package_files.go
@@ -23,9 +23,23 @@ type PackageFile struct {
 	downloadPath string
 }
 
+// Select the appropriate hash 
+func (f *PackageFile) SelectChecksum(hashSelector string) string {
+	if hashSelector == "SHA1" {
+		return f.Checksums.SHA1
+	}
+	if hashSelector == "SHA256" {
+		return f.Checksums.SHA256
+	}
+	if hashSelector == "SHA512" {
+		return f.Checksums.SHA512
+	}
+	return f.Checksums.MD5
+}
+
 // Verify that package file is present and correct
 func (f *PackageFile) Verify(packagePool aptly.PackagePool) (bool, error) {
-	poolPath, err := packagePool.Path(f.Filename, f.Checksums.MD5)
+	poolPath, err := packagePool.Path(f.Filename, f.SelectChecksum(packagePool.HashSelector()))
 	if err != nil {
 		return false, err
 	}

--- a/deb/package_files_test.go
+++ b/deb/package_files_test.go
@@ -60,3 +60,13 @@ func (s *PackageFilesSuite) TestDownloadURL(c *C) {
 func (s *PackageFilesSuite) TestHash(c *C) {
 	c.Check(s.files.Hash(), Equals, uint64(0xc8901eedd79ac51b))
 }
+
+func (s *PackageFilesSuite) TestSelectChecksum(c *C) {
+	c.Check(s.files[0].SelectChecksum(""), Equals, "1e8cba92c41420aa7baa8a5718d67122")
+	c.Check(s.files[0].SelectChecksum("MD5"), Equals, "1e8cba92c41420aa7baa8a5718d67122")
+	c.Check(s.files[0].SelectChecksum("SHA1"), Equals, "46955e48cad27410a83740a21d766ce362364024")
+	c.Check(s.files[0].SelectChecksum("SHA256"), Equals, "eb4afb9885cba6dc70cccd05b910b2dbccc02c5900578be5e99f0d3dbf9d76a5")
+
+	// We check about the empty string since the package file does not have a SHA512 set
+	c.Check(s.files[0].SelectChecksum("SHA512"), Equals, "")
+}

--- a/deb/package_test.go
+++ b/deb/package_test.go
@@ -394,11 +394,52 @@ func (s *PackageSuite) TestFilepathList(c *C) {
 	c.Check(list, DeepEquals, []string{"1e/8c/alien-arena-common_7.40-2_i386.deb"})
 }
 
+func (s *PackageSuite) TestFilepathListSHA256(c *C) {
+	packagePool := files.NewPackagePool(c.MkDir())
+	packagePool.SetHashSelector("SHA256")
+	p := NewPackageFromControlFile(s.stanza)
+
+	list, err := p.FilepathList(packagePool)
+	c.Check(err, IsNil)
+	c.Check(list, DeepEquals, []string{"eb/4a/alien-arena-common_7.40-2_i386.deb"})
+}
+
 func (s *PackageSuite) TestDownloadList(c *C) {
 	packagePool := files.NewPackagePool(c.MkDir())
 	p := NewPackageFromControlFile(s.stanza)
 	p.Files()[0].Checksums.Size = 5
 	poolPath, _ := packagePool.Path(p.Files()[0].Filename, p.Files()[0].Checksums.MD5)
+
+	list, err := p.DownloadList(packagePool)
+	c.Check(err, IsNil)
+	c.Check(list, DeepEquals, []PackageDownloadTask{
+		{
+			RepoURI:         "pool/contrib/a/alien-arena/alien-arena-common_7.40-2_i386.deb",
+			DestinationPath: poolPath,
+			Checksums: utils.ChecksumInfo{Size: 5,
+				MD5:    "1e8cba92c41420aa7baa8a5718d67122",
+				SHA1:   "46955e48cad27410a83740a21d766ce362364024",
+				SHA256: "eb4afb9885cba6dc70cccd05b910b2dbccc02c5900578be5e99f0d3dbf9d76a5"}}})
+
+	err = os.MkdirAll(filepath.Dir(poolPath), 0755)
+	c.Assert(err, IsNil)
+
+	file, err := os.Create(poolPath)
+	c.Assert(err, IsNil)
+	file.WriteString("abcde")
+	file.Close()
+
+	list, err = p.DownloadList(packagePool)
+	c.Check(err, IsNil)
+	c.Check(list, DeepEquals, []PackageDownloadTask{})
+}
+
+func (s *PackageSuite) TestDownloadListSHA256(c *C) {
+	packagePool := files.NewPackagePool(c.MkDir())
+	packagePool.SetHashSelector("SHA256")
+	p := NewPackageFromControlFile(s.stanza)
+	p.Files()[0].Checksums.Size = 5
+	poolPath, _ := packagePool.Path(p.Files()[0].Filename, p.Files()[0].Checksums.SHA256)
 
 	list, err := p.DownloadList(packagePool)
 	c.Check(err, IsNil)
@@ -445,6 +486,27 @@ func (s *PackageSuite) TestVerifyFiles(c *C) {
 	p.Files()[0].Checksums.Size = 5
 
 	result, err = p.VerifyFiles(packagePool)
+	c.Check(err, IsNil)
+	c.Check(result, Equals, true)
+}
+
+func (s *PackageSuite) TestVerifyFilesSHA256(c *C) {
+	p := NewPackageFromControlFile(s.stanza)
+
+	packagePool := files.NewPackagePool(c.MkDir())
+	packagePool.SetHashSelector("SHA256")
+	poolPath, _ := packagePool.Path(p.Files()[0].Filename, p.Files()[0].Checksums.SHA256)
+
+	err := os.MkdirAll(filepath.Dir(poolPath), 0755)
+	c.Assert(err, IsNil)
+
+	file, err := os.Create(poolPath)
+	c.Assert(err, IsNil)
+	file.WriteString("abcde")
+	file.Close()
+	p.Files()[0].Checksums.Size = 5
+
+	result, err := p.VerifyFiles(packagePool)
 	c.Check(err, IsNil)
 	c.Check(result, Equals, true)
 }

--- a/files/package_pool.go
+++ b/files/package_pool.go
@@ -35,7 +35,7 @@ func (pool *PackagePool) RelativePath(filename string, hash string) (string, err
 	}
 
 	if len(hash) < 4 {
-		return "", fmt.Errorf("unable to compute pool location for filename %v, %s is missing", filename, pool.hashSelector)
+		return "", fmt.Errorf("unable to compute pool location for filename %v, %s is missing", filename, pool.HashSelector())
 	}
 
 	return filepath.Join(hash[0:2], hash[2:4], filename), nil
@@ -62,7 +62,7 @@ func (pool *PackagePool) SetHashSelector(hashSelector string) {
 		hashSelector = "SHA512"
 	} else {
 		if hashSelector != "" {
-			fmt.Printf("Invalid hash name %s, defaulting to MD5", hashSelector)
+			fmt.Printf("Invalid hash name %s, defaulting to MD5\n", hashSelector)
 		}
 		hashSelector = "MD5"
 	}
@@ -71,7 +71,7 @@ func (pool *PackagePool) SetHashSelector(hashSelector string) {
 	if pool.hashSelector == "" {
 		pool.hashSelector = hashSelector
 	} else if pool.hashSelector != hashSelector {
-		fmt.Printf("Hash name used for file paths can only be set once, current %s, new %s", pool.hashSelector, hashSelector)
+		fmt.Printf("Hash name used for file paths can only be set once, current %s, new %s\n", pool.hashSelector, hashSelector)
 	}
 }
 

--- a/files/package_pool.go
+++ b/files/package_pool.go
@@ -14,6 +14,7 @@ import (
 type PackagePool struct {
 	sync.Mutex
 	rootPath string
+	hashSelector string
 }
 
 // Check interface
@@ -27,22 +28,56 @@ func NewPackagePool(root string) *PackagePool {
 }
 
 // RelativePath returns path relative to pool's root for package files given MD5 and original filename
-func (pool *PackagePool) RelativePath(filename string, hashMD5 string) (string, error) {
+func (pool *PackagePool) RelativePath(filename string, hash string) (string, error) {
 	filename = filepath.Base(filename)
 	if filename == "." || filename == "/" {
 		return "", fmt.Errorf("filename %s is invalid", filename)
 	}
 
-	if len(hashMD5) < 4 {
-		return "", fmt.Errorf("unable to compute pool location for filename %v, MD5 is missing", filename)
+	if len(hash) < 4 {
+		return "", fmt.Errorf("unable to compute pool location for filename %v, %s is missing", filename, pool.hashSelector)
 	}
 
-	return filepath.Join(hashMD5[0:2], hashMD5[2:4], filename), nil
+	return filepath.Join(hash[0:2], hash[2:4], filename), nil
+}
+
+// Return name of hash that is used for selecting the file path
+func (pool *PackagePool) HashSelector() string {
+	if pool.hashSelector == "" {
+		pool.hashSelector = "MD5"
+	} 
+
+	return pool.hashSelector
+}
+
+// Set the name of hash selector that is used for selecting the file path
+func (pool *PackagePool) SetHashSelector(hashSelector string) {
+	if hashSelector == "MD5" || hashSelector == "md5" || hashSelector == "MD5Sum" || hashSelector == "MD5sum" {
+		hashSelector = "MD5"
+	} else if hashSelector == "SHA1" || hashSelector == "sha1" {
+		hashSelector = "SHA1"
+	} else if hashSelector == "SHA256" || hashSelector == "sha256" {
+		hashSelector = "SHA256"
+	} else if hashSelector == "SHA512" || hashSelector == "sha512" {
+		hashSelector = "SHA512"
+	} else {
+		if hashSelector != "" {
+			fmt.Printf("Invalid hash name %s, defaulting to MD5", hashSelector)
+		}
+		hashSelector = "MD5"
+	}
+
+	// You only have one chance to set the hash selector
+	if pool.hashSelector == "" {
+		pool.hashSelector = hashSelector
+	} else if pool.hashSelector != hashSelector {
+		fmt.Printf("Hash name used for file paths can only be set once, current %s, new %s", pool.hashSelector, hashSelector)
+	}
 }
 
 // Path returns full path to package file in pool given any name and hash of file contents
-func (pool *PackagePool) Path(filename string, hashMD5 string) (string, error) {
-	relative, err := pool.RelativePath(filename, hashMD5)
+func (pool *PackagePool) Path(filename string, hash string) (string, error) {
+	relative, err := pool.RelativePath(filename, hash)
 	if err != nil {
 		return "", err
 	}
@@ -113,7 +148,7 @@ func (pool *PackagePool) Remove(path string) (size int64, err error) {
 }
 
 // Import copies file into package pool
-func (pool *PackagePool) Import(path string, hashMD5 string) error {
+func (pool *PackagePool) Import(path string, hash string) error {
 	pool.Lock()
 	defer pool.Unlock()
 
@@ -128,7 +163,7 @@ func (pool *PackagePool) Import(path string, hashMD5 string) error {
 		return err
 	}
 
-	poolPath, err := pool.Path(path, hashMD5)
+	poolPath, err := pool.Path(path, hash)
 	if err != nil {
 		return err
 	}

--- a/files/package_pool_test.go
+++ b/files/package_pool_test.go
@@ -17,7 +17,6 @@ var _ = Suite(&PackagePoolSuite{})
 
 func (s *PackagePoolSuite) SetUpTest(c *C) {
 	s.pool = NewPackagePool(c.MkDir())
-
 }
 
 func (s *PackagePoolSuite) TestRelativePath(c *C) {
@@ -117,4 +116,27 @@ func (s *PackagePoolSuite) TestImportOverwrite(c *C) {
 
 	err := s.pool.Import(debFile, "91b1a1480b90b9e269ca44d897b12575")
 	c.Check(err, ErrorMatches, "unable to import into pool.*")
+}
+
+func (s *PackagePoolSuite) TestHashSelectorDefault(c *C) {
+	hashName := s.pool.HashSelector()
+	c.Check(hashName, Equals, "MD5")
+
+	// Check that once set the setting is immutable
+	s.pool.SetHashSelector("SHA256")
+	hashName = s.pool.HashSelector()
+	c.Check(hashName, Equals, "MD5")
+}
+
+func (s *PackagePoolSuite) TestHashSelectorSHA256(c *C) {
+	s.pool.SetHashSelector("SHA256")
+
+	// Check that the setting can be set
+	hashName := s.pool.HashSelector()
+	c.Check(hashName, Equals, "SHA256")
+
+	// Check that once set the setting is immutable
+	s.pool.SetHashSelector("MD5")
+	hashName = s.pool.HashSelector()
+	c.Check(hashName, Equals, "SHA256")
 }

--- a/man/aptly.1
+++ b/man/aptly.1
@@ -76,7 +76,8 @@ Configuration file is stored in JSON format (default values shown below):
       "tenant": "",
       "tenantid": ""
     }
-  }
+  },
+  "hashSelector": ""
 }
 .
 .fi
@@ -141,6 +142,10 @@ configuration of Amazon S3 publishing endpoints (see below)
 .TP
 \fBSwiftPublishEndpoints\fR
 configuration of OpenStack Swift publishing endpoints (see below)
+.
+.TP
+\fBhashSelector\fR
+selects which hash to use for pool path names, default is MD5, can be set to SHA1, SHA256, or SHA512 before initializing the pool directory
 .
 .SH "S3 PUBLISHING ENDPOINTS"
 aptly could be configured to publish repository directly to Amazon S3 (or S3\-compatible cloud storage)\. First, publishing endpoints should be described in aptly configuration file\. Each endpoint has name and associated settings:

--- a/man/aptly.1.ronn.tmpl
+++ b/man/aptly.1.ronn.tmpl
@@ -68,7 +68,8 @@ Configuration file is stored in JSON format (default values shown below):
           "tenant": "",
           "tenantid": ""
         }
-      }
+      },
+      "hashSelector": ""
     }
 
 Options:
@@ -120,6 +121,10 @@ Options:
 
   * `SwiftPublishEndpoints`:
     configuration of OpenStack Swift publishing endpoints (see below)
+
+  * `hashSelector`:
+    selects which hash to use for pool path names, default is MD5, can be set to SHA1,
+    SHA256, or SHA512 before initializing the pool directory
 
 ## S3 PUBLISHING ENDPOINTS
 

--- a/system/t02_config/ConfigShowTest_gold
+++ b/system/t02_config/ConfigShowTest_gold
@@ -14,5 +14,6 @@
     "ppaCodename": "",
     "skipContentsPublishing": false,
     "S3PublishEndpoints": {},
-    "SwiftPublishEndpoints": {}
+    "SwiftPublishEndpoints": {},
+    "hashSelector": "MD5"
 }

--- a/system/t02_config/CreateConfigTest_gold
+++ b/system/t02_config/CreateConfigTest_gold
@@ -14,5 +14,6 @@
   "ppaCodename": "",
   "skipContentsPublishing": false,
   "S3PublishEndpoints": {},
-  "SwiftPublishEndpoints": {}
+  "SwiftPublishEndpoints": {},
+  "hashSelector": "MD5"
 }

--- a/utils/config.go
+++ b/utils/config.go
@@ -24,6 +24,7 @@ type ConfigStructure struct {
 	SkipContentsPublishing bool                        `json:"skipContentsPublishing"`
 	S3PublishRoots         map[string]S3PublishRoot    `json:"S3PublishEndpoints"`
 	SwiftPublishRoots      map[string]SwiftPublishRoot `json:"SwiftPublishEndpoints"`
+	HashSelector           string                      `json:"hashSelector"`
 }
 
 // S3PublishRoot describes single S3 publishing entry point
@@ -76,6 +77,7 @@ var Config = ConfigStructure{
 	PpaCodename:            "",
 	S3PublishRoots:         map[string]S3PublishRoot{},
 	SwiftPublishRoots:      map[string]SwiftPublishRoot{},
+	HashSelector:           "MD5",
 }
 
 // LoadConfig loads configuration from json file

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -95,7 +95,8 @@ func (s *ConfigSuite) TestSaveConfig(c *C) {
 		"      \"prefix\": \"\",\n"+
 		"      \"container\": \"repo\"\n"+
 		"    }\n"+
-		"  }\n"+
+		"  },\n"+
+		"  \"hashSelector\": \"\"\n"+
 		"}")
 }
 


### PR DESCRIPTION
Fixes #228, #442 

## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

This change adds a new configuration field "hashSelector" that defaults to MD5 but can be set to SHA1, SHA256, or SHA512.  The debian package specification does not require the MD5 hash be present, but does require that SHA256 is present.  Aptly currently is using the MD5 hash value from remote repositories to construct path names in the pool directory.  This change allows the hash function to be configured in aptly.conf.  With the change the and the hashSelector configured to SHA256, repositories hosted on Artifactory or BinTray can be mirrored by Aptly.  Without this change they cannot.  

The default behavior of Aptly is unchanged, so there should not be any compatibility issues with existing installations or existing documentation.

## Checklist

- [x] unit-test added (if change is algorithm)
- [X] functional test added/updated (if change is functional)
- [X] man page updated (if applicable)
- [X] bash completion updated (if applicable)
- [X] documentation updated
- [X] author name in `AUTHORS`