### PR TITLE
Allow published repo to reside on different filesystem

### DIFF
--- a/utils/checksum.go
+++ b/utils/checksum.go
@@ -11,6 +11,23 @@ import (
 	"os"
 )
 
+// MD5ChecksumForFile computes just the MD5 hash and not all the others
+func MD5ChecksumForFile(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	hash := md5.New()
+	_, err = io.Copy(hash, file)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%x", hash.Sum(nil)), nil
+}
+
 // ChecksumInfo represents checksums for a single file
 type ChecksumInfo struct {
 	Size   int64

--- a/utils/samefilesystem.go
+++ b/utils/samefilesystem.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+	"os"
+	"syscall"
+)
+
+// SameFilesystem checks whether two existing paths reside on the same
+// filesystem and can thus be hardlinked
+func SameFilesystem(path1, path2 string) (bool, error) {
+	path1Stat, err := os.Stat(path1)
+	if err != nil {
+		return false, err
+	}
+
+	path2Stat, err := os.Stat(path2)
+	if err != nil {
+		return false, err
+	}
+
+	path1Sys := path1Stat.Sys().(*syscall.Stat_t)
+	path2Sys := path2Stat.Sys().(*syscall.Stat_t)
+
+	return path1Sys.Dev == path2Sys.Dev, nil
+}


### PR DESCRIPTION
## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

Currently packages are hardlinked from the internal pool to the published repo, which requires them to reside on the same filesystem. This precludes mounting the published repo from a remote machine, e.g. via NFS or sshfs, which would be desirable to physically separate the machine hosting the internal pool and signing key from the machine serving the published repo.

Autodetect such a setup and, if found, copy files instead of using hardlinks.

Add helpers to check whether two given paths reside on the same filesystem and to check whether an already published package file is identical to the one to be published by comparing their MD5 hashes.

## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [ ] author name in `AUTHORS`
