### PR TITLE
Automatic versioning for aptly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_install:
   - mkdir -p $GOPATH/src/github.com/smira
   - ln -s $TRAVIS_BUILD_DIR $GOPATH/src/github.com/smira || true
   - cd $GOPATH/src/github.com/smira/aptly
+  - make version
 install:
   - make prepare
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ check:
 	gometalinter --vendor --vendored-linters --config=linter.json ./...
 
 install:
-	go install -x -v -ldflags "-X main.Version=$(VERSION)"
+	go install -v -ldflags "-X main.Version=$(VERSION)"
 
 system-test: install
 	if [ ! -e ~/aptly-fixture-db ]; then git clone https://github.com/aptly-dev/aptly-fixture-db.git ~/aptly-fixture-db/; fi

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GOVERSION=$(shell go version | awk '{print $$3;}')
+VERSION=$(shell git describe --tags | sed 's@^v@@' | sed 's@-@+@g')
 PACKAGES=context database deb files http query swift s3 utils
-ALL_PACKAGES=api aptly context cmd console database deb files http query swift s3 utils
 PYTHON?=python
 TESTS?=
 BINPATH?=$(GOPATH)/bin
@@ -39,12 +39,12 @@ check:
 	gometalinter --vendor --vendored-linters --config=linter.json ./...
 
 install:
-	go install -v
+	go install -x -v -ldflags "-X main.Version=$(VERSION)"
 
 system-test: install
 	if [ ! -e ~/aptly-fixture-db ]; then git clone https://github.com/aptly-dev/aptly-fixture-db.git ~/aptly-fixture-db/; fi
 	if [ ! -e ~/aptly-fixture-pool ]; then git clone https://github.com/aptly-dev/aptly-fixture-pool.git ~/aptly-fixture-pool/; fi
-	PATH=$(BINPATH)/:$(PATH) $(PYTHON) system/run.py --long $(TESTS)
+	APTLY_VERSION=$(VERSION) PATH=$(BINPATH)/:$(PATH) $(PYTHON) system/run.py --long $(TESTS)
 
 travis: $(TRAVIS_TARGET) check system-test
 
@@ -79,4 +79,7 @@ goxc:
 man:
 	make -C man
 
-.PHONY: coverage.out man
+version:
+	@echo $(VERSION)
+
+.PHONY: coverage.out man version

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ If you have Go environment set up, you can build aptly from source by running (g
     mkdir -p $GOPATH/src/github.com/smira/aptly
     git clone https://github.com/smira/aptly $GOPATH/src/github.com/smira/aptly
     cd $GOPATH/src/github.com/smira/aptly
-    go install .
+    make install
 
 Binary would be installed to ```$GOPATH/bin/aptly``.
 

--- a/aptly/version.go
+++ b/aptly/version.go
@@ -1,7 +1,7 @@
 package aptly
 
-// Version of aptly
-const Version = "0.9.8~dev"
+// Version of aptly (filled in at link time)
+var Version string
 
 // EnableDebug triggers some debugging features
 const EnableDebug = false

--- a/deb/version_test.go
+++ b/deb/version_test.go
@@ -96,6 +96,9 @@ func (s *VersionSuite) TestCompareVersions(c *C) {
 
 	c.Check(CompareVersions("1.0~beta1~svn1245", "1.0~beta1"), Equals, -1)
 	c.Check(CompareVersions("1.0~beta1", "1.0"), Equals, -1)
+
+	c.Check(CompareVersions("1.0-133-avc", "1.1"), Equals, -1)
+	c.Check(CompareVersions("1.0-133-avc", "1.0"), Equals, 1)
 }
 
 func (s *VersionSuite) TestParseDependency(c *C) {

--- a/main.go
+++ b/main.go
@@ -3,9 +3,19 @@ package main
 import (
 	"os"
 
+	"github.com/smira/aptly/aptly"
 	"github.com/smira/aptly/cmd"
 )
 
+// Version variable, filled in at link time
+var Version string
+
 func main() {
+	if Version == "" {
+		Version = "unknown"
+	}
+
+	aptly.Version = Version
+
 	os.Exit(cmd.Run(cmd.RootCommand(), os.Args[1:], true))
 }

--- a/system/run.py
+++ b/system/run.py
@@ -98,6 +98,12 @@ def run(include_long_tests=False, capture_results=False, tests=None, filters=Non
         sys.exit(1)
 
 if __name__ == "__main__":
+    if 'APTLY_VERSION' not in os.environ:
+        try:
+            os.environ['APTLY_VERSION'] = os.popen("make version").read().strip()
+        except BaseException, e:
+            print "Failed to capture current version: ", e
+
     os.chdir(os.path.realpath(os.path.dirname(sys.argv[0])))
     random.seed()
     include_long_tests = False

--- a/system/t01_version/VersionTest_gold
+++ b/system/t01_version/VersionTest_gold
@@ -1,1 +1,1 @@
-aptly version: 0.9.8~dev
+aptly version: ${APTLY_VERSION}

--- a/system/t01_version/__init__.py
+++ b/system/t01_version/__init__.py
@@ -9,5 +9,6 @@ class VersionTest(BaseTest):
     """
     version should match
     """
+    gold_processor = BaseTest.expand_environ
 
     runCmd = "aptly version"

--- a/system/t10_task/RunTask1Test_gold
+++ b/system/t10_task/RunTask1Test_gold
@@ -21,6 +21,6 @@ End command output: ------------------------------
 4) [Running]: version
 
 Begin command output: ----------------------------
-aptly version: 0.9.8~dev
+aptly version: ${APTLY_VERSION}
 
 End command output: ------------------------------

--- a/system/t10_task/run.py
+++ b/system/t10_task/run.py
@@ -5,6 +5,8 @@ class RunTask1Test(BaseTest):
     """
     task run: simple commands, 1-word command
     """
+    gold_processor = BaseTest.expand_environ
+
     runCmd = "aptly task run repo list, repo create local, repo drop local, version"
 
 

--- a/system/t12_api/systemd_handover.py
+++ b/system/t12_api/systemd_handover.py
@@ -1,9 +1,10 @@
 import requests_unixsocket
-import time
 import urllib
+import os
 import os.path
 
 from lib import BaseTest
+
 
 class SystemdAPIHandoverTest(BaseTest):
     aptly_server = None
@@ -37,9 +38,9 @@ class SystemdAPIHandoverTest(BaseTest):
     Verify we can listen on a unix domain socket.
     """
     def check(self):
-        if self.aptly_server == None:
+        if self.aptly_server is None:
             print("Skipping test as we failed to setup a listener.")
             return
         session = requests_unixsocket.Session()
         r = session.get('http+unix://%s/api/version' % urllib.quote(self.socket_path, safe=''))
-        self.check_equal(r.json(), {'Version': '0.9.8~dev'})
+        self.check_equal(r.json(), {'Version': os.environ['APTLY_VERSION']})

--- a/system/t12_api/unix_socket.py
+++ b/system/t12_api/unix_socket.py
@@ -1,8 +1,10 @@
 import requests_unixsocket
 import time
+import os
 import urllib
 
 from lib import BaseTest
+
 
 class UnixSocketAPITest(BaseTest):
     aptly_server = None
@@ -33,4 +35,4 @@ class UnixSocketAPITest(BaseTest):
         r = session.get('http+unix://%s/api/version' % urllib.quote(UnixSocketAPITest.socket_path, safe=''))
         # Just needs to come back, we actually don't care much about the code.
         # Only needs to verify that the socket is actually responding.
-        self.check_equal(r.json(), {'Version': '0.9.8~dev'})
+        self.check_equal(r.json(), {'Version': os.environ['APTLY_VERSION']})

--- a/system/t12_api/version.py
+++ b/system/t12_api/version.py
@@ -1,4 +1,5 @@
 from api_lib import APITest
+import os
 
 
 class VersionAPITest(APITest):
@@ -7,4 +8,4 @@ class VersionAPITest(APITest):
     """
 
     def check(self):
-        self.check_equal(self.get("/api/version").json(), {'Version': '0.9.8~dev'})
+        self.check_equal(self.get("/api/version").json(), {'Version': os.environ['APTLY_VERSION']})


### PR DESCRIPTION
New version format:

* for releases, `x.y.z` (follows tag without leading `v`)
* for nightly builds, `x.y.z+N+hash` (previous version, not the upcoming one)

This means that each nightly build `aptly` would report
correct version now.

Version is now complied into the aptly binary, system tests
automatically check for current version, no need to update them
anymore.

