### PR TITLE
Refactoring: use checksums instead of MD5 for pool/published

### DIFF
--- a/aptly/interfaces.go
+++ b/aptly/interfaces.go
@@ -13,15 +13,15 @@ import (
 // PackagePool stores all the package files, deduplicating them.
 type PackagePool interface {
 	// Path returns full path to package file in pool given any name and hash of file contents
-	Path(filename string, hashMD5 string) (string, error)
-	// RelativePath returns path relative to pool's root for package files given MD5 and original filename
-	RelativePath(filename string, hashMD5 string) (string, error)
+	Path(filename string, checksums utils.ChecksumInfo) (string, error)
+	// RelativePath returns path relative to pool's root for package files given checksums and original filename
+	RelativePath(filename string, checksums utils.ChecksumInfo) (string, error)
 	// FilepathList returns file paths of all the files in the pool
 	FilepathList(progress Progress) ([]string, error)
 	// Remove deletes file in package pool returns its size
 	Remove(path string) (size int64, err error)
 	// Import copies file into package pool
-	Import(path string, hashMD5 string) error
+	Import(path string, checksums utils.ChecksumInfo) error
 }
 
 // PublishedStorage is abstraction of filesystem storing all published repositories
@@ -35,7 +35,7 @@ type PublishedStorage interface {
 	// Remove removes single file under public path
 	Remove(path string) error
 	// LinkFromPool links package file from pool to dist's pool location
-	LinkFromPool(publishedDirectory string, sourcePool PackagePool, sourcePath, sourceMD5 string, force bool) error
+	LinkFromPool(publishedDirectory string, sourcePool PackagePool, sourcePath string, sourceChecksums utils.ChecksumInfo, force bool) error
 	// Filelist returns list of files under prefix
 	Filelist(prefix string) ([]string, error)
 	// RenameFile renames (moves) file

--- a/cmd/package_show.go
+++ b/cmd/package_show.go
@@ -88,7 +88,7 @@ func aptlyPackageShow(cmd *commander.Command, args []string) error {
 		if withFiles {
 			fmt.Printf("Files in the pool:\n")
 			for _, f := range p.Files() {
-				path, err := context.PackagePool().Path(f.Filename, f.Checksums.MD5)
+				path, err := context.PackagePool().Path(f.Filename, f.Checksums)
 				if err != nil {
 					return err
 				}

--- a/deb/import.go
+++ b/deb/import.go
@@ -128,7 +128,7 @@ func ImportPackageFiles(list *PackageList, packageFiles []string, forceReplace b
 			p.UpdateFiles([]PackageFile{{Filename: filepath.Base(file), Checksums: checksums}})
 		}
 
-		err = pool.Import(file, checksums.MD5)
+		err = pool.Import(file, checksums)
 		if err != nil {
 			reporter.Warning("Unable to import file %s into pool: %s", file, err)
 			failedFiles = append(failedFiles, file)
@@ -143,7 +143,7 @@ func ImportPackageFiles(list *PackageList, packageFiles []string, forceReplace b
 				continue
 			}
 			sourceFile := filepath.Join(filepath.Dir(file), filepath.Base(f.Filename))
-			err = pool.Import(sourceFile, f.Checksums.MD5)
+			err = pool.Import(sourceFile, f.Checksums)
 			if err != nil {
 				reporter.Warning("Unable to import file %s into pool: %s", sourceFile, err)
 				failedFiles = append(failedFiles, file)

--- a/deb/package.go
+++ b/deb/package.go
@@ -418,7 +418,7 @@ func (p *Package) CalculateContents(packagePool aptly.PackagePool, progress aptl
 	}
 
 	file := p.Files()[0]
-	path, err := packagePool.Path(file.Filename, file.Checksums.MD5)
+	path, err := packagePool.Path(file.Filename, file.Checksums)
 	if err != nil {
 		if progress != nil {
 			progress.ColoredPrintf("@y[!]@| @!Failed to build pool path: @| %s", err)
@@ -547,7 +547,7 @@ func (p *Package) LinkFromPool(publishedStorage aptly.PublishedStorage, packageP
 	}
 
 	for i, f := range p.Files() {
-		sourcePath, err := packagePool.Path(f.Filename, f.Checksums.MD5)
+		sourcePath, err := packagePool.Path(f.Filename, f.Checksums)
 		if err != nil {
 			return err
 		}
@@ -555,7 +555,7 @@ func (p *Package) LinkFromPool(publishedStorage aptly.PublishedStorage, packageP
 		relPath := filepath.Join("pool", component, poolDir)
 		publishedDirectory := filepath.Join(prefix, relPath)
 
-		err = publishedStorage.LinkFromPool(publishedDirectory, packagePool, sourcePath, f.Checksums.MD5, force)
+		err = publishedStorage.LinkFromPool(publishedDirectory, packagePool, sourcePath, f.Checksums, force)
 		if err != nil {
 			return err
 		}
@@ -607,7 +607,7 @@ func (p *Package) DownloadList(packagePool aptly.PackagePool) (result []PackageD
 	result = make([]PackageDownloadTask, 0, 1)
 
 	for _, f := range p.Files() {
-		poolPath, err := packagePool.Path(f.Filename, f.Checksums.MD5)
+		poolPath, err := packagePool.Path(f.Filename, f.Checksums)
 		if err != nil {
 			return nil, err
 		}
@@ -645,7 +645,7 @@ func (p *Package) FilepathList(packagePool aptly.PackagePool) ([]string, error) 
 	result := make([]string, len(p.Files()))
 
 	for i, f := range p.Files() {
-		result[i], err = packagePool.RelativePath(f.Filename, f.Checksums.MD5)
+		result[i], err = packagePool.RelativePath(f.Filename, f.Checksums)
 		if err != nil {
 			return nil, err
 		}

--- a/deb/package_files.go
+++ b/deb/package_files.go
@@ -26,7 +26,7 @@ type PackageFile struct {
 
 // Verify that package file is present and correct
 func (f *PackageFile) Verify(packagePool aptly.PackagePool) (bool, error) {
-	poolPath, err := packagePool.Path(f.Filename, f.Checksums.MD5)
+	poolPath, err := packagePool.Path(f.Filename, f.Checksums)
 	if err != nil {
 		return false, err
 	}

--- a/deb/package_files_test.go
+++ b/deb/package_files_test.go
@@ -30,7 +30,7 @@ func (s *PackageFilesSuite) SetUpTest(c *C) {
 
 func (s *PackageFilesSuite) TestVerify(c *C) {
 	packagePool := files.NewPackagePool(c.MkDir())
-	poolPath, _ := packagePool.Path(s.files[0].Filename, s.files[0].Checksums.MD5)
+	poolPath, _ := packagePool.Path(s.files[0].Filename, s.files[0].Checksums)
 
 	result, err := s.files[0].Verify(packagePool)
 	c.Check(err, IsNil)

--- a/deb/package_test.go
+++ b/deb/package_test.go
@@ -367,7 +367,7 @@ func (s *PackageSuite) TestLinkFromPool(c *C) {
 	publishedStorage := files.NewPublishedStorage(c.MkDir())
 	p := NewPackageFromControlFile(s.stanza)
 
-	poolPath, _ := packagePool.Path(p.Files()[0].Filename, p.Files()[0].Checksums.MD5)
+	poolPath, _ := packagePool.Path(p.Files()[0].Filename, p.Files()[0].Checksums)
 	err := os.MkdirAll(filepath.Dir(poolPath), 0755)
 	c.Assert(err, IsNil)
 
@@ -399,7 +399,7 @@ func (s *PackageSuite) TestDownloadList(c *C) {
 	packagePool := files.NewPackagePool(c.MkDir())
 	p := NewPackageFromControlFile(s.stanza)
 	p.Files()[0].Checksums.Size = 5
-	poolPath, _ := packagePool.Path(p.Files()[0].Filename, p.Files()[0].Checksums.MD5)
+	poolPath, _ := packagePool.Path(p.Files()[0].Filename, p.Files()[0].Checksums)
 
 	list, err := p.DownloadList(packagePool)
 	c.Check(err, IsNil)
@@ -429,7 +429,7 @@ func (s *PackageSuite) TestVerifyFiles(c *C) {
 	p := NewPackageFromControlFile(s.stanza)
 
 	packagePool := files.NewPackagePool(c.MkDir())
-	poolPath, _ := packagePool.Path(p.Files()[0].Filename, p.Files()[0].Checksums.MD5)
+	poolPath, _ := packagePool.Path(p.Files()[0].Filename, p.Files()[0].Checksums)
 
 	err := os.MkdirAll(filepath.Dir(poolPath), 0755)
 	c.Assert(err, IsNil)

--- a/deb/publish_test.go
+++ b/deb/publish_test.go
@@ -132,7 +132,7 @@ func (s *PublishedRepoSuite) SetUpTest(c *C) {
 	s.repo5, _ = NewPublishedRepo("files:other", "ppa", "maverick", []string{"source"}, []string{"main"}, []interface{}{s.localRepo}, s.factory)
 	s.repo5.SkipContents = true
 
-	poolPath, _ := s.packagePool.Path(s.p1.Files()[0].Filename, s.p1.Files()[0].Checksums.MD5)
+	poolPath, _ := s.packagePool.Path(s.p1.Files()[0].Filename, s.p1.Files()[0].Checksums)
 	err := os.MkdirAll(filepath.Dir(poolPath), 0755)
 	f, err := os.Create(poolPath)
 	c.Assert(err, IsNil)

--- a/files/public.go
+++ b/files/public.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 
 	"github.com/smira/aptly/aptly"
+	"github.com/smira/aptly/utils"
 )
 
 // PublishedStorage abstract file system with public dirs (published repos)
@@ -81,7 +82,7 @@ func (storage *PublishedStorage) RemoveDirs(path string, progress aptly.Progress
 //
 // LinkFromPool returns relative path for the published file to be included in package index
 func (storage *PublishedStorage) LinkFromPool(publishedDirectory string, sourcePool aptly.PackagePool,
-	sourcePath, sourceMD5 string, force bool) error {
+	sourcePath string, sourceChecksums utils.ChecksumInfo, force bool) error {
 	// verify that package pool is local pool is filesystem pool
 	_ = sourcePool.(*PackagePool)
 

--- a/files/public_test.go
+++ b/files/public_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"github.com/smira/aptly/utils"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -154,7 +156,7 @@ func (s *PublishedStorageSuite) TestLinkFromPool(c *C) {
 		err = ioutil.WriteFile(t.sourcePath, []byte("Contents"), 0644)
 		c.Assert(err, IsNil)
 
-		err = s.storage.LinkFromPool(filepath.Join(t.prefix, "pool", t.component, t.poolDirectory), pool, t.sourcePath, "", false)
+		err = s.storage.LinkFromPool(filepath.Join(t.prefix, "pool", t.component, t.poolDirectory), pool, t.sourcePath, utils.ChecksumInfo{}, false)
 		c.Assert(err, IsNil)
 
 		st, err := os.Stat(filepath.Join(s.storage.rootPath, t.prefix, t.expectedFilename))
@@ -172,7 +174,7 @@ func (s *PublishedStorageSuite) TestLinkFromPool(c *C) {
 	err = ioutil.WriteFile(sourcePath, []byte("Contents"), 0644)
 	c.Assert(err, IsNil)
 
-	err = s.storage.LinkFromPool(filepath.Join("", "pool", "main", "m/mars-invaders"), pool, sourcePath, "", false)
+	err = s.storage.LinkFromPool(filepath.Join("", "pool", "main", "m/mars-invaders"), pool, sourcePath, utils.ChecksumInfo{}, false)
 	c.Check(err, ErrorMatches, ".*file already exists and is different")
 
 	st, err := os.Stat(sourcePath)
@@ -182,7 +184,7 @@ func (s *PublishedStorageSuite) TestLinkFromPool(c *C) {
 	c.Check(int(info.Nlink), Equals, 1)
 
 	// linking with force
-	err = s.storage.LinkFromPool(filepath.Join("", "pool", "main", "m/mars-invaders"), pool, sourcePath, "", true)
+	err = s.storage.LinkFromPool(filepath.Join("", "pool", "main", "m/mars-invaders"), pool, sourcePath, utils.ChecksumInfo{}, true)
 	c.Check(err, IsNil)
 
 	st, err = os.Stat(sourcePath)

--- a/s3/public_test.go
+++ b/s3/public_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 
 	"github.com/smira/aptly/files"
+	"github.com/smira/aptly/utils"
 )
 
 type PublishedStorageSuite struct {
@@ -233,25 +234,25 @@ func (s *PublishedStorageSuite) TestLinkFromPool(c *C) {
 	c.Assert(err, IsNil)
 
 	// first link from pool
-	err = s.storage.LinkFromPool(filepath.Join("", "pool", "main", "m/mars-invaders"), pool, sourcePath, "c1df1da7a1ce305a3b60af9d5733ac1d", false)
+	err = s.storage.LinkFromPool(filepath.Join("", "pool", "main", "m/mars-invaders"), pool, sourcePath, utils.ChecksumInfo{MD5: "c1df1da7a1ce305a3b60af9d5733ac1d"}, false)
 	c.Check(err, IsNil)
 
 	c.Check(s.GetFile(c, "pool/main/m/mars-invaders/mars-invaders_1.03.deb"), DeepEquals, []byte("Contents"))
 
 	// duplicate link from pool
-	err = s.storage.LinkFromPool(filepath.Join("", "pool", "main", "m/mars-invaders"), pool, sourcePath, "c1df1da7a1ce305a3b60af9d5733ac1d", false)
+	err = s.storage.LinkFromPool(filepath.Join("", "pool", "main", "m/mars-invaders"), pool, sourcePath, utils.ChecksumInfo{MD5: "c1df1da7a1ce305a3b60af9d5733ac1d"}, false)
 	c.Check(err, IsNil)
 
 	c.Check(s.GetFile(c, "pool/main/m/mars-invaders/mars-invaders_1.03.deb"), DeepEquals, []byte("Contents"))
 
 	// link from pool with conflict
-	err = s.storage.LinkFromPool(filepath.Join("", "pool", "main", "m/mars-invaders"), pool, sourcePath2, "e9dfd31cc505d51fc26975250750deab", false)
+	err = s.storage.LinkFromPool(filepath.Join("", "pool", "main", "m/mars-invaders"), pool, sourcePath2, utils.ChecksumInfo{MD5: "e9dfd31cc505d51fc26975250750deab"}, false)
 	c.Check(err, ErrorMatches, ".*file already exists and is different.*")
 
 	c.Check(s.GetFile(c, "pool/main/m/mars-invaders/mars-invaders_1.03.deb"), DeepEquals, []byte("Contents"))
 
 	// link from pool with conflict and force
-	err = s.storage.LinkFromPool(filepath.Join("", "pool", "main", "m/mars-invaders"), pool, sourcePath2, "e9dfd31cc505d51fc26975250750deab", true)
+	err = s.storage.LinkFromPool(filepath.Join("", "pool", "main", "m/mars-invaders"), pool, sourcePath2, utils.ChecksumInfo{MD5: "e9dfd31cc505d51fc26975250750deab"}, true)
 	c.Check(err, IsNil)
 
 	c.Check(s.GetFile(c, "pool/main/m/mars-invaders/mars-invaders_1.03.deb"), DeepEquals, []byte("Spam"))

--- a/swift/public.go
+++ b/swift/public.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ncw/swift"
 	"github.com/smira/aptly/aptly"
 	"github.com/smira/aptly/files"
+	"github.com/smira/aptly/utils"
 )
 
 // PublishedStorage abstract file system with published files (actually hosted on Swift)
@@ -186,7 +187,7 @@ func (storage *PublishedStorage) RemoveDirs(path string, progress aptly.Progress
 //
 // LinkFromPool returns relative path for the published file to be included in package index
 func (storage *PublishedStorage) LinkFromPool(publishedDirectory string, sourcePool aptly.PackagePool,
-	sourcePath, sourceMD5 string, force bool) error {
+	sourcePath string, sourceChecksums utils.ChecksumInfo, force bool) error {
 	// verify that package pool is local pool in filesystem
 	_ = sourcePool.(*files.PackagePool)
 
@@ -205,7 +206,11 @@ func (storage *PublishedStorage) LinkFromPool(publishedDirectory string, sourceP
 			return fmt.Errorf("error getting information about %s from %s: %s", poolPath, storage, err)
 		}
 	} else {
-		if !force && info.Hash != sourceMD5 {
+		if sourceChecksums.MD5 == "" {
+			return fmt.Errorf("unable to compare object, MD5 checksum missing")
+		}
+
+		if !force && info.Hash != sourceChecksums.MD5 {
 			return fmt.Errorf("error putting file to %s: file already exists and is different: %s", poolPath, storage)
 
 		}

--- a/swift/public_test.go
+++ b/swift/public_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ncw/swift/swifttest"
 
 	"github.com/smira/aptly/files"
+	"github.com/smira/aptly/utils"
 )
 
 type PublishedStorageSuite struct {
@@ -161,7 +162,7 @@ func (s *PublishedStorageSuite) TestLinkFromPool(c *C) {
 	c.Assert(err, IsNil)
 
 	// first link from pool
-	err = s.storage.LinkFromPool(filepath.Join("", "pool", "main", "m/mars-invaders"), pool, sourcePath, "c1df1da7a1ce305a3b60af9d5733ac1d", false)
+	err = s.storage.LinkFromPool(filepath.Join("", "pool", "main", "m/mars-invaders"), pool, sourcePath, utils.ChecksumInfo{MD5: "c1df1da7a1ce305a3b60af9d5733ac1d"}, false)
 	c.Check(err, IsNil)
 
 	data, err := s.storage.conn.ObjectGetBytes("test", "pool/main/m/mars-invaders/mars-invaders_1.03.deb")
@@ -169,7 +170,7 @@ func (s *PublishedStorageSuite) TestLinkFromPool(c *C) {
 	c.Check(data, DeepEquals, []byte("Contents"))
 
 	// duplicate link from pool
-	err = s.storage.LinkFromPool(filepath.Join("", "pool", "main", "m/mars-invaders"), pool, sourcePath, "c1df1da7a1ce305a3b60af9d5733ac1d", false)
+	err = s.storage.LinkFromPool(filepath.Join("", "pool", "main", "m/mars-invaders"), pool, sourcePath, utils.ChecksumInfo{MD5: "c1df1da7a1ce305a3b60af9d5733ac1d"}, false)
 	c.Check(err, IsNil)
 
 	data, err = s.storage.conn.ObjectGetBytes("test", "pool/main/m/mars-invaders/mars-invaders_1.03.deb")
@@ -177,7 +178,7 @@ func (s *PublishedStorageSuite) TestLinkFromPool(c *C) {
 	c.Check(data, DeepEquals, []byte("Contents"))
 
 	// link from pool with conflict
-	err = s.storage.LinkFromPool(filepath.Join("", "pool", "main", "m/mars-invaders"), pool, sourcePath2, "e9dfd31cc505d51fc26975250750deab", false)
+	err = s.storage.LinkFromPool(filepath.Join("", "pool", "main", "m/mars-invaders"), pool, sourcePath2, utils.ChecksumInfo{MD5: "e9dfd31cc505d51fc26975250750deab"}, false)
 	c.Check(err, ErrorMatches, ".*file already exists and is different.*")
 
 	data, err = s.storage.conn.ObjectGetBytes("test", "pool/main/m/mars-invaders/mars-invaders_1.03.deb")
@@ -185,7 +186,7 @@ func (s *PublishedStorageSuite) TestLinkFromPool(c *C) {
 	c.Check(data, DeepEquals, []byte("Contents"))
 
 	// link from pool with conflict and force
-	err = s.storage.LinkFromPool(filepath.Join("", "pool", "main", "m/mars-invaders"), pool, sourcePath2, "e9dfd31cc505d51fc26975250750deab", true)
+	err = s.storage.LinkFromPool(filepath.Join("", "pool", "main", "m/mars-invaders"), pool, sourcePath2, utils.ChecksumInfo{MD5: "e9dfd31cc505d51fc26975250750deab"}, true)
 	c.Check(err, IsNil)
 
 	data, err = s.storage.conn.ObjectGetBytes("test", "pool/main/m/mars-invaders/mars-invaders_1.03.deb")


### PR DESCRIPTION
This is related to #506

As a first step, don't pass MD5 explicitly, pass checksum info object,
so that as a next step we can choose which hash to use.

There should be no functional changes so far.

Next step: stop returning explicit paths from public package pool.

## Checklist

- [x] unit-test added (if change is algorithm)
- [x] functional test added/updated (if change is functional)
- [x] man page updated (if applicable)
- [x] bash completion updated (if applicable)
- [x] documentation updated
- [x] author name in `AUTHORS`
