### PR TITLE
Fix temporary contents DB being left behind after publishing

### DIFF
--- a/deb/publish.go
+++ b/deb/publish.go
@@ -473,8 +473,17 @@ func (p *PublishedRepo) Publish(packagePool aptly.PackagePool, publishedStorageP
 	if err != nil {
 		return err
 	}
-	defer tempDB.Close()
-	defer tempDB.Drop()
+	defer func() {
+		var e error
+		e = tempDB.Close()
+		if e != nil && progress != nil {
+			progress.Printf("failed to close temp DB: %s", err)
+		}
+		e = tempDB.Drop()
+		if e != nil && progress != nil {
+			progress.Printf("failed to drop temp DB: %s", err)
+		}
+	}()
 
 	if progress != nil {
 		progress.Printf("Loading packages...\n")


### PR DESCRIPTION
## Description of the Change

NB: Go `defer` order execution is reverse to the order `defer` statements
are executed.

So before the change, `Drop()` was called before `Close()`, which was no-op.

Change that to explicit order in single func, print errors if they happen.

Fixes #543

## Checklist

- [x] unit-test added (if change is algorithm)
- [x] functional test added/updated (if change is functional)
- [x] man page updated (if applicable)
- [x] bash completion updated (if applicable)
- [x] documentation updated
- [x] author name in `AUTHORS`
