### PR TITLE
Fix bug with `PoolPath` field being overwritten on mirror update

### DIFF
--- a/aptly/interfaces.go
+++ b/aptly/interfaces.go
@@ -23,7 +23,7 @@ type PackagePool interface {
 	//
 	// if poolPath is empty, poolPath is generated automatically based on checksum info (if available)
 	// in any case, if function returns true, it also fills back checksums with complete information about the file in the pool
-	Verify(poolPath, basename string, checksums *utils.ChecksumInfo, checksumStorage ChecksumStorage) (bool, error)
+	Verify(poolPath, basename string, checksums *utils.ChecksumInfo, checksumStorage ChecksumStorage) (string, bool, error)
 	// Import copies file into package pool
 	//
 	// - srcPath is full path to source file as it is now

--- a/deb/package.go
+++ b/deb/package.go
@@ -629,14 +629,15 @@ type PackageDownloadTask struct {
 func (p *Package) DownloadList(packagePool aptly.PackagePool, checksumStorage aptly.ChecksumStorage) (result []PackageDownloadTask, err error) {
 	result = make([]PackageDownloadTask, 0, 1)
 
-	for idx, f := range p.Files() {
-		verified, err := f.Verify(packagePool, checksumStorage)
+	files := p.Files()
+	for idx := range files {
+		verified, err := files[idx].Verify(packagePool, checksumStorage)
 		if err != nil {
 			return nil, err
 		}
 
 		if !verified {
-			result = append(result, PackageDownloadTask{File: &p.Files()[idx]})
+			result = append(result, PackageDownloadTask{File: &files[idx]})
 		}
 	}
 

--- a/deb/package_files.go
+++ b/deb/package_files.go
@@ -27,7 +27,12 @@ type PackageFile struct {
 
 // Verify that package file is present and correct
 func (f *PackageFile) Verify(packagePool aptly.PackagePool, checksumStorage aptly.ChecksumStorage) (bool, error) {
-	return packagePool.Verify(f.PoolPath, f.Filename, &f.Checksums, checksumStorage)
+	generatedPoolPath, exists, err := packagePool.Verify(f.PoolPath, f.Filename, &f.Checksums, checksumStorage)
+	if exists && err == nil {
+		f.PoolPath = generatedPoolPath
+	}
+
+	return exists, err
 }
 
 // GetPoolPath returns path to the file in the pool

--- a/system/t06_publish/PublishSnapshot37Test_gold
+++ b/system/t06_publish/PublishSnapshot37Test_gold
@@ -1,0 +1,13 @@
+Loading packages...
+Generating metadata files and linking package files...
+Finalizing metadata files...
+Signing file 'Release' with gpg, please enter your passphrase when prompted:
+Clearsigning file 'Release' with gpg, please enter your passphrase when prompted:
+
+Snapshot wheezy has been successfully published.
+Please setup your webserver to serve directory '${HOME}/.aptly/public' with autoindexing.
+Now you can add following line to apt sources:
+  deb http://your-server/ wheezy main
+Don't forget to add your GPG key to apt with apt-key.
+
+You can also use `aptly serve` to publish your repositories over HTTP quickly.

--- a/system/t06_publish/snapshot.py
+++ b/system/t06_publish/snapshot.py
@@ -1001,3 +1001,18 @@ class PublishSnapshot36Test(BaseTest):
         self.check_not_exists('public/dists/maverick/main/Contents-i386.gz')
         self.check_exists('public/dists/maverick/main/binary-amd64/Release')
         self.check_not_exists('public/dists/maverick/main/Contents-amd64.gz')
+
+
+class PublishSnapshot37Test(BaseTest):
+    """
+    publish snapshot: mirror with double mirror update
+    """
+    fixtureGpg = True
+    fixtureCmds = [
+        "aptly -architectures=i386,amd64 mirror create -keyring=aptlytest.gpg -filter='$$Source (gnupg)' -with-udebs wheezy http://mirror.yandex.ru/debian/ wheezy main non-free",
+        "aptly mirror update -keyring=aptlytest.gpg wheezy",
+        "aptly mirror update -keyring=aptlytest.gpg wheezy",
+        "aptly snapshot create wheezy from mirror wheezy",
+    ]
+    runCmd = "aptly publish snapshot -keyring=${files}/aptly.pub -secret-keyring=${files}/aptly.sec wheezy"
+    gold_processor = BaseTest.expand_environ


### PR DESCRIPTION
While updating mirror, if package file is already in pool path,
field `PoolPath` was left as empty which results in package file
being unavailable later on while publishing.

Fixes #600

## Description of the Change

This bug was introduced in 1.1.0

## Checklist

- [x] unit-test added (if change is algorithm)
- [x] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [x] author name in `AUTHORS`
