### PR TITLE
Fix S3 path caching double-prefix

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,3 +28,4 @@ List of contributors, in chronological order:
 * Charles Hsu (https://github.com/charz)
 * Clemens Rabe (https://github.com/seeraven)
 * TJ Merritt (https://github.com/tjmerritt)
+* Matt Martyn (https://github.com/MMartyn)

--- a/s3/public.go
+++ b/s3/public.go
@@ -267,7 +267,7 @@ func (storage *PublishedStorage) LinkFromPool(publishedDirectory, baseName strin
 	poolPath := filepath.Join(storage.prefix, relPath)
 
 	if storage.pathCache == nil {
-		paths, md5s, err := storage.internalFilelist(storage.prefix, true)
+		paths, md5s, err := storage.internalFilelist("", true)
 		if err != nil {
 			return errors.Wrap(err, "error caching paths under prefix")
 		}

--- a/s3/public_test.go
+++ b/s3/public_test.go
@@ -257,4 +257,19 @@ func (s *PublishedStorageSuite) TestLinkFromPool(c *C) {
 	c.Check(err, IsNil)
 
 	c.Check(s.GetFile(c, "pool/main/m/mars-invaders/mars-invaders_1.03.deb"), DeepEquals, []byte("Spam"))
+
+	// for prefixed storage:
+	// first link from pool
+	err = s.prefixedStorage.LinkFromPool(filepath.Join("", "pool", "main", "m/mars-invaders"), "mars-invaders_1.03.deb", pool, src1, cksum1, false)
+	c.Check(err, IsNil)
+
+	// 2nd link from pool, providing wrong path for source file
+	//
+	// this test should check that file already exists in S3 and skip upload (which would fail if not skipped)
+	s.prefixedStorage.pathCache = nil
+	err = s.prefixedStorage.LinkFromPool(filepath.Join("", "pool", "main", "m/mars-invaders"), "mars-invaders_1.03.deb", pool, "wrong-looks-like-pathcache-doesnt-work", cksum1, false)
+	c.Check(err, IsNil)
+
+	c.Check(s.GetFile(c, "lala/pool/main/m/mars-invaders/mars-invaders_1.03.deb"), DeepEquals, []byte("Contents"))
+
 }


### PR DESCRIPTION
Original PR: #621
Fixes: #619

I've added unit-test to Martyn's PR.

## Description 

Without this fix, if `prefix` is set on S3 publish endpoint,
aptly would incorrectly build path cache and re-upload every object
on publish.

## Checklist

- [x] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [x] author name in `AUTHORS`
