### PR TITLE
Expose the context outside of the cmd package.

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -29,3 +29,8 @@ func InitContext(flags *flag.FlagSet) error {
 
 	return err
 }
+
+// GetContext gives access to the context
+func GetContext() *ctx.AptlyContext {
+	return context
+}


### PR DESCRIPTION

## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

Skyscrapers wants to contribute back what we use from the community. We are a heavy user of [Concourse](http://concourse.ci/). Concourse supports monitoring changes in different artifacts by way of resource types. We are contributing a new resource type to monitor the release of new versions of a package and trigger builds when that happens:

https://github.com/skyscrapers/apt-package-resource

We are still in development for this resource, but so far I had to make one change to the `aptly` code base to support is in reusing the code: have access to the command context.

This resource type is my first Go contribution which means that also this PR is possibly not the way you should do things in Go. I'm open to learn how to do it better then.

## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [ ] author name in `AUTHORS`
