### PR TITLE
Allow uppercase package name in package query expressions

### DIFF
--- a/query/syntax.go
+++ b/query/syntax.go
@@ -135,7 +135,7 @@ func (p *parser) D() deb.PackageQuery {
 	operator, value := p.Condition()
 
 	r, _ := utf8.DecodeRuneInString(field)
-	if strings.HasPrefix(field, "$") || unicode.IsUpper(r) {
+	if strings.HasPrefix(field, "$") || (unicode.IsUpper(r) && !strings.ContainsRune(field, '_')) {
 		// special field or regular field
 		q := &deb.FieldQuery{Field: field, Relation: operatorToRelation(operator), Value: value}
 		if q.Relation == deb.VersionRegexp {

--- a/query/syntax_test.go
+++ b/query/syntax_test.go
@@ -57,6 +57,18 @@ func (s *SyntaxSuite) TestParsing(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(q, DeepEquals, &deb.PkgQuery{Pkg: "alien-data", Version: "1.3.4~dev", Arch: "i386"})
 
+	l, _ = lex("query", "Alien-data_1.3.4~dev_i386")
+	q, err = parse(l)
+
+	c.Assert(err, IsNil)
+	c.Check(q, DeepEquals, &deb.PkgQuery{Pkg: "Alien-data", Version: "1.3.4~dev", Arch: "i386"})
+
+	l, _ = lex("query", "Name")
+	q, err = parse(l)
+
+	c.Assert(err, IsNil)
+	c.Check(q, DeepEquals, &deb.FieldQuery{Field: "Name"})
+
 	l, _ = lex("query", "package (> 5.3.7) {amd64}")
 	q, err = parse(l)
 


### PR DESCRIPTION
Fixes: #636

Before this fix, aptly was always treating strings starting with
uppercase letter as field name, which was breaking package queries
like `VMware-Horizon-Client_4.5.0_all`.

Now aptly accepts only fields which don't contain underscore, and
everything else would be parsed as package reference.

## Checklist

- [x] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [x] author name in `AUTHORS`
