### PR TITLE
Prefer exact match on package name over provides match

### DIFF
--- a/deb/list.go
+++ b/deb/list.go
@@ -441,18 +441,6 @@ func (l *PackageList) Search(dep Dependency, allMatches bool) (searchResults []*
 		panic("list not indexed, can't search")
 	}
 
-	if dep.Relation == VersionDontCare {
-		for _, p := range l.providesIndex[dep.Pkg] {
-			if dep.Architecture == "" || p.MatchesArchitecture(dep.Architecture) {
-				searchResults = append(searchResults, p)
-
-				if !allMatches {
-					break
-				}
-			}
-		}
-	}
-
 	i := sort.Search(len(l.packagesIndex), func(j int) bool { return l.packagesIndex[j].Name >= dep.Pkg })
 
 	for i < len(l.packagesIndex) && l.packagesIndex[i].Name == dep.Pkg {
@@ -466,6 +454,18 @@ func (l *PackageList) Search(dep Dependency, allMatches bool) (searchResults []*
 		}
 
 		i++
+	}
+
+	if dep.Relation == VersionDontCare {
+		for _, p := range l.providesIndex[dep.Pkg] {
+			if dep.Architecture == "" || p.MatchesArchitecture(dep.Architecture) {
+				searchResults = append(searchResults, p)
+
+				if !allMatches {
+					break
+				}
+			}
+		}
 	}
 
 	return

--- a/system/t04_mirror/SearchMirror4Test_gold
+++ b/system/t04_mirror/SearchMirror4Test_gold
@@ -85,6 +85,7 @@ tar_1.26+dfsg-0.1_amd64
 tar_1.26+dfsg-0.1_i386
 ttf-bitstream-vera_1.10-8_all
 ttf-dejavu-core_2.33-3_all
+ttf-freefont_20120503-1_all
 ucf_3.0025+nmu3_all
 x11-common_1:7.7+3~deb7u1_all
 xfonts-encodings_1:1.0.4-1_all

--- a/system/t05_snapshot/SearchSnapshot4Test_gold
+++ b/system/t05_snapshot/SearchSnapshot4Test_gold
@@ -85,6 +85,7 @@ tar_1.26+dfsg-0.1_amd64
 tar_1.26+dfsg-0.1_i386
 ttf-bitstream-vera_1.10-8_all
 ttf-dejavu-core_2.33-3_all
+ttf-freefont_20120503-1_all
 ucf_3.0025+nmu3_all
 x11-common_1:7.7+3~deb7u1_all
 xfonts-encodings_1:1.0.4-1_all

--- a/system/t09_repo/SearchRepo4Test_gold
+++ b/system/t09_repo/SearchRepo4Test_gold
@@ -85,6 +85,7 @@ tar_1.26+dfsg-0.1_amd64
 tar_1.26+dfsg-0.1_i386
 ttf-bitstream-vera_1.10-8_all
 ttf-dejavu-core_2.33-3_all
+ttf-freefont_20120503-1_all
 ucf_3.0025+nmu3_all
 x11-common_1:7.7+3~deb7u1_all
 xfonts-encodings_1:1.0.4-1_all


### PR DESCRIPTION
When searching for packages which might satisfy given dependency,
aptly was first returning packages which `Provides` mentioned
name. By default aptly is picking up only first match (unless
follow all variants options is enabled), so `Provides:` takes
precedence over exact package name match.

Invert this logic by searching first for package name match.

Fixes #618

## Checklist

- [ ] unit-test added (if change is algorithm)
- [x] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [x] author name in `AUTHORS`
