### PR TITLE
Fix incomplete dependencies with follow-all-variants

### DIFF
--- a/deb/list.go
+++ b/deb/list.go
@@ -124,6 +124,14 @@ func NewPackageListFromRefList(reflist *PackageRefList, collection *PackageColle
 	return result, nil
 }
 
+// Has checks whether package is already in the list
+func (l *PackageList) Has(p *Package) bool {
+	key := l.keyFunc(p)
+	_, ok := l.packages[key]
+
+	return ok
+}
+
 // Add appends package to package list, additionally checking for uniqueness
 func (l *PackageList) Add(p *Package) error {
 	key := l.keyFunc(p)
@@ -511,15 +519,27 @@ func (l *PackageList) FilterWithProgress(queries []PackageQuery, withDependencie
 
 			// try to satisfy dependencies
 			for _, dep := range missing {
-				// dependency might have already been satisfied
-				// with packages already been added
-				if result.Search(dep, false) != nil {
-					continue
+				if dependencyOptions&DepFollowAllVariants == 0 {
+					// dependency might have already been satisfied
+					// with packages already been added
+					//
+					// when follow-all-variants is enabled, we need to try to expand anyway,
+					// as even if dependency is satisfied now, there might be other ways to satisfy dependency
+					if result.Search(dep, false) != nil {
+						if dependencyOptions&DepVerboseResolve == DepVerboseResolve && progress != nil {
+							progress.ColoredPrintf("@{y}Already satisfied dependency@|: %s with %s", &dep, result.Search(dep, true))
+						}
+						continue
+					}
 				}
 
 				searchResults := l.Search(dep, true)
 				if len(searchResults) > 0 {
 					for _, p := range searchResults {
+						if result.Has(p) {
+							continue
+						}
+
 						if dependencyOptions&DepVerboseResolve == DepVerboseResolve && progress != nil {
 							progress.ColoredPrintf("@{g}Injecting package@|: %s", p)
 						}

--- a/deb/version.go
+++ b/deb/version.go
@@ -262,6 +262,13 @@ func ParseDependency(dep string) (d Dependency, err error) {
 	}
 
 	d.Pkg = strings.TrimSpace(dep[0:i])
+	if strings.ContainsRune(d.Pkg, ':') {
+		parts := strings.SplitN(d.Pkg, ":", 2)
+		d.Pkg, d.Architecture = parts[0], parts[1]
+		if d.Architecture == "any" {
+			d.Architecture = ""
+		}
+	}
 
 	rel := ""
 	if dep[i+1] == '>' || dep[i+1] == '<' || dep[i+1] == '=' {

--- a/deb/version_test.go
+++ b/deb/version_test.go
@@ -164,6 +164,20 @@ func (s *VersionSuite) TestParseDependency(c *C) {
 	c.Check(d.Version, Equals, "1.6")
 	c.Check(d.Architecture, Equals, "i386")
 
+	d, e = ParseDependency("python:any (>= 2.7~)")
+	c.Check(e, IsNil)
+	c.Check(d.Pkg, Equals, "python")
+	c.Check(d.Relation, Equals, VersionGreaterOrEqual)
+	c.Check(d.Version, Equals, "2.7~")
+	c.Check(d.Architecture, Equals, "")
+
+	d, e = ParseDependency("python:amd64 (>= 2.7~)")
+	c.Check(e, IsNil)
+	c.Check(d.Pkg, Equals, "python")
+	c.Check(d.Relation, Equals, VersionGreaterOrEqual)
+	c.Check(d.Version, Equals, "2.7~")
+	c.Check(d.Architecture, Equals, "amd64")
+
 	d, e = ParseDependency("dpkg{i386}")
 	c.Check(e, IsNil)
 	c.Check(d.Pkg, Equals, "dpkg")

--- a/system/t05_snapshot/PullSnapshot15Test_gold
+++ b/system/t05_snapshot/PullSnapshot15Test_gold
@@ -2,6 +2,7 @@
 
     [snap1]: Snapshot from mirror [wheezy-main]: http://mirror.yandex.ru/debian/ wheezy
     [snap2]: Snapshot from mirror [wheezy-backports]: http://mirror.yandex.ru/debian/ wheezy-backports
+Already satisfied dependency: init-system-helpers (>= 1.18~) [i386] with [init-system-helpers_1.18~bpo70+1_all]
 Building indexes...
 Dependencies would be pulled into snapshot:
 Injecting package: init-system-helpers_1.18~bpo70+1_all


### PR DESCRIPTION
When `-dep-follow-all-variants` option is enabled, dependency resolving
process shouldn't stop even if dependency is already satisfied - there
mgiht be other ways to satisfy dependency.

Also fix issue with parsing multiarch specs like
`python:any`.

Fixes #615

## Checklist

- [x] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [x] author name in `AUTHORS`
