### PR TITLE
fix linting by using new maligned linter instead of aligncheck

### DIFF
--- a/deb/remote.go
+++ b/deb/remote.go
@@ -592,7 +592,7 @@ func (repo *RemoteRepo) Decode(input []byte) error {
 	if err != nil {
 		if strings.HasPrefix(err.Error(), "codec.decoder: readContainerLen: Unrecognized descriptor byte: hex: 80") {
 			// probably it is broken DB from go < 1.2, try decoding w/o time.Time
-			var repo11 struct {
+			var repo11 struct { // nolint: maligned
 				UUID             string
 				Name             string
 				ArchiveRoot      string

--- a/linter.json
+++ b/linter.json
@@ -12,7 +12,7 @@
         "staticcheck",
         "varcheck",
         "structcheck",
-        "aligncheck",
+        "maligned",
         "vetshadow",
         "goconst",
         "interfacer"

--- a/system/lib.py
+++ b/system/lib.py
@@ -194,7 +194,7 @@ class BaseTest(object):
     def check_output(self):
         try:
             self.verify_match(self.get_gold(), self.output, match_prepare=self.outputMatchPrepare)
-        except:
+        except:  # noqa: E722
             if self.captureResults:
                 if self.outputMatchPrepare is not None:
                     self.output = self.outputMatchPrepare(self.output)
@@ -207,7 +207,7 @@ class BaseTest(object):
         output = self.run_cmd(command, expected_code=expected_code)
         try:
             self.verify_match(self.get_gold(gold_name), output, match_prepare)
-        except:
+        except:  # noqa: E722
             if self.captureResults:
                 if match_prepare is not None:
                     output = match_prepare(output)
@@ -228,7 +228,7 @@ class BaseTest(object):
         try:
 
             self.verify_match(self.get_gold(gold_name), contents, match_prepare=match_prepare)
-        except:
+        except:  # noqa: E722
             if self.captureResults:
                 if match_prepare is not None:
                     contents = match_prepare(contents)
@@ -241,7 +241,7 @@ class BaseTest(object):
         contents = open(self.checkedFile, "r").read()
         try:
             self.verify_match(self.get_gold(), contents)
-        except:
+        except:  # noqa: E722
             if self.captureResults:
                 with open(self.get_gold_filename(), "w") as f:
                     f.write(contents)

--- a/utils/config.go
+++ b/utils/config.go
@@ -7,7 +7,7 @@ import (
 )
 
 // ConfigStructure is structure of main configuration
-type ConfigStructure struct { // nolint: aligncheck
+type ConfigStructure struct { // nolint: maligned
 	RootDir                string                           `json:"rootDir"`
 	DownloadConcurrency    int                              `json:"downloadConcurrency"`
 	DownloadLimit          int64                            `json:"downloadSpeedLimit"`


### PR DESCRIPTION
upstream switched the alignment check backend and in doing so fails to run
if the old backend is defined in the config.

also skip alignment linting on a struct we use for byte decoding as we have
no choice in its member order.

Also see https://github.com/alecthomas/gometalinter/commit/90d987842c8b2b8591691f6227d855a3a992e202

Fixes all PRs failing on linting