### PR TITLE
S3 backend: include path prefix in removal requests.

### DIFF
--- a/s3/public.go
+++ b/s3/public.go
@@ -183,12 +183,12 @@ func (storage *PublishedStorage) putFile(path string, source io.ReadSeeker) erro
 func (storage *PublishedStorage) Remove(path string) error {
 	params := &s3.DeleteObjectInput{
 		Bucket: aws.String(storage.bucket),
-		Key:    aws.String(path),
+		Key:    aws.String(filepath.Join(storage.prefix,path)),
 	}
 	_, err := storage.s3.DeleteObject(params)
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("error deleting %s from %s", path, storage))
-	}
+		}
 
 	if storage.plusWorkaround && strings.Contains(path, "+") {
 		// try to remove workaround version, but don't care about result

--- a/s3/public_test.go
+++ b/s3/public_test.go
@@ -160,6 +160,13 @@ func (s *PublishedStorageSuite) TestRemove(c *C) {
 	c.Check(err, IsNil)
 
 	s.AssertNoFile(c, "a/b")
+
+	s.PutFile(c, "lala/xyz", []byte("test"))
+
+	errp := s.prefixedStorage.Remove("xyz")
+	c.Check(errp, IsNil)
+
+	s.AssertNoFile(c, "lala/xyz")
 }
 
 func (s *PublishedStorageSuite) TestRemovePlusWorkaround(c *C) {


### PR DESCRIPTION
DELETE requests, both for temporary files and no longer referenced
packages, lacked the configured path prefix and therefor were not
removed if a prefix is configured.

## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

Adds the path prefix to Remove() so that temporary and unreferenced pool files are properly removed.

## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [ ] author name in `AUTHORS`
