### PR TITLE
Do not loose downloaded files in mirror update

### DIFF
--- a/cmd/mirror_update.go
+++ b/cmd/mirror_update.go
@@ -190,6 +190,8 @@ func aptlyMirrorUpdate(cmd *commander.Command, args []string) error {
 						pushError(e)
 						continue
 					}
+
+					task.Finished = true
 				case <-abort:
 					return
 				}
@@ -208,10 +210,6 @@ func aptlyMirrorUpdate(cmd *commander.Command, args []string) error {
 
 	context.Progress().ShutdownBar()
 
-	if len(errors) > 0 {
-		return fmt.Errorf("unable to update: download errors:\n  %s", strings.Join(errors, "\n  "))
-	}
-
 	err = context.ReOpenDatabase()
 	if err != nil {
 		return fmt.Errorf("unable to update: %s", err)
@@ -225,6 +223,10 @@ func aptlyMirrorUpdate(cmd *commander.Command, args []string) error {
 		context.Progress().AddBar(1)
 
 		task := &queue[idx]
+
+		if !task.Finished {
+			continue
+		}
 
 		// and import it back to the pool
 		task.File.PoolPath, err = context.PackagePool().Import(task.TempDownPath, task.File.Filename, &task.File.Checksums, true, context.CollectionFactory().ChecksumCollection())
@@ -246,6 +248,10 @@ func aptlyMirrorUpdate(cmd *commander.Command, args []string) error {
 	}
 
 	context.Progress().ShutdownBar()
+
+	if len(errors) > 0 {
+		return fmt.Errorf("unable to update: download errors:\n  %s", strings.Join(errors, "\n  "))
+	}
 
 	repo.FinalizeDownload(context.CollectionFactory(), context.Progress())
 	err = context.CollectionFactory().RemoteRepoCollection().Update(repo)

--- a/deb/package.go
+++ b/deb/package.go
@@ -622,6 +622,7 @@ type PackageDownloadTask struct {
 	File         *PackageFile
 	Additional   []PackageDownloadTask
 	TempDownPath string
+	Finished     bool
 }
 
 // DownloadList returns list of missing package files for download in format


### PR DESCRIPTION
Fixes #651 

## Description of the Change

If some files during mirror update fail to download all downloaded files would be lost and redownloaded again in a second mirror update call.

This fix import files which have successfully been downloaded but mirror update is still marked as failed. What this doesn't fix is when aptly process is canceled. This I guess will be addressed with fix for #545 

## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [x] author name in `AUTHORS`
