### PR TITLE
Fix race in API related to `LoadComplete()`

### DIFF
--- a/api/graph.go
+++ b/api/graph.go
@@ -24,14 +24,14 @@ func apiGraph(c *gin.Context) {
 
 	factory := context.CollectionFactory()
 
-	factory.RemoteRepoCollection().RLock()
-	defer factory.RemoteRepoCollection().RUnlock()
-	factory.LocalRepoCollection().RLock()
-	defer factory.LocalRepoCollection().RUnlock()
-	factory.SnapshotCollection().RLock()
-	defer factory.SnapshotCollection().RUnlock()
-	factory.PublishedRepoCollection().RLock()
-	defer factory.PublishedRepoCollection().RUnlock()
+	factory.RemoteRepoCollection().Lock()
+	defer factory.RemoteRepoCollection().Unlock()
+	factory.LocalRepoCollection().Lock()
+	defer factory.LocalRepoCollection().Unlock()
+	factory.SnapshotCollection().Lock()
+	defer factory.SnapshotCollection().Unlock()
+	factory.PublishedRepoCollection().Lock()
+	defer factory.PublishedRepoCollection().Unlock()
 
 	graph, err := deb.BuildGraph(factory, layout)
 	if err != nil {

--- a/api/publish.go
+++ b/api/publish.go
@@ -60,8 +60,8 @@ func apiPublishList(c *gin.Context) {
 	defer snapshotCollection.RUnlock()
 
 	collection := context.CollectionFactory().PublishedRepoCollection()
-	collection.RLock()
-	defer collection.RUnlock()
+	collection.Lock()
+	defer collection.Unlock()
 
 	result := make([]*deb.PublishedRepo, 0, collection.Len())
 
@@ -128,8 +128,8 @@ func apiPublishRepoOrSnapshot(c *gin.Context) {
 		var snapshot *deb.Snapshot
 
 		snapshotCollection := context.CollectionFactory().SnapshotCollection()
-		snapshotCollection.RLock()
-		defer snapshotCollection.RUnlock()
+		snapshotCollection.Lock()
+		defer snapshotCollection.Unlock()
 
 		for _, source := range b.Sources {
 			components = append(components, source.Component)
@@ -152,8 +152,8 @@ func apiPublishRepoOrSnapshot(c *gin.Context) {
 		var localRepo *deb.LocalRepo
 
 		localCollection := context.CollectionFactory().LocalRepoCollection()
-		localCollection.RLock()
-		defer localCollection.RUnlock()
+		localCollection.Lock()
+		defer localCollection.Unlock()
 
 		for _, source := range b.Sources {
 			components = append(components, source.Component)
@@ -253,12 +253,12 @@ func apiPublishUpdateSwitch(c *gin.Context) {
 
 	// published.LoadComplete would touch local repo collection
 	localRepoCollection := context.CollectionFactory().LocalRepoCollection()
-	localRepoCollection.RLock()
-	defer localRepoCollection.RUnlock()
+	localRepoCollection.Lock()
+	defer localRepoCollection.Unlock()
 
 	snapshotCollection := context.CollectionFactory().SnapshotCollection()
-	snapshotCollection.RLock()
-	defer snapshotCollection.RUnlock()
+	snapshotCollection.Lock()
+	defer snapshotCollection.Unlock()
 
 	collection := context.CollectionFactory().PublishedRepoCollection()
 	collection.Lock()
@@ -357,8 +357,8 @@ func apiPublishDrop(c *gin.Context) {
 
 	// published.LoadComplete would touch local repo collection
 	localRepoCollection := context.CollectionFactory().LocalRepoCollection()
-	localRepoCollection.RLock()
-	defer localRepoCollection.RUnlock()
+	localRepoCollection.Lock()
+	defer localRepoCollection.Unlock()
 
 	collection := context.CollectionFactory().PublishedRepoCollection()
 	collection.Lock()

--- a/api/repos.go
+++ b/api/repos.go
@@ -162,8 +162,8 @@ func apiReposDrop(c *gin.Context) {
 // GET /api/repos/:name/packages
 func apiReposPackagesShow(c *gin.Context) {
 	collection := context.CollectionFactory().LocalRepoCollection()
-	collection.RLock()
-	defer collection.RUnlock()
+	collection.Lock()
+	defer collection.Unlock()
 
 	repo, err := collection.ByName(c.Params.ByName("name"))
 	if err != nil {

--- a/api/snapshot.go
+++ b/api/snapshot.go
@@ -47,8 +47,8 @@ func apiSnapshotsCreateFromMirror(c *gin.Context) {
 	}
 
 	collection := context.CollectionFactory().RemoteRepoCollection()
-	collection.RLock()
-	defer collection.RUnlock()
+	collection.Lock()
+	defer collection.Unlock()
 
 	snapshotCollection := context.CollectionFactory().SnapshotCollection()
 	snapshotCollection.Lock()
@@ -186,8 +186,8 @@ func apiSnapshotsCreateFromRepository(c *gin.Context) {
 	}
 
 	collection := context.CollectionFactory().LocalRepoCollection()
-	collection.RLock()
-	defer collection.RUnlock()
+	collection.Lock()
+	defer collection.Unlock()
 
 	snapshotCollection := context.CollectionFactory().SnapshotCollection()
 	snapshotCollection.Lock()
@@ -276,8 +276,8 @@ func apiSnapshotsUpdate(c *gin.Context) {
 // GET /api/snapshots/:name
 func apiSnapshotsShow(c *gin.Context) {
 	collection := context.CollectionFactory().SnapshotCollection()
-	collection.RLock()
-	defer collection.RUnlock()
+	collection.Lock()
+	defer collection.Unlock()
 
 	snapshot, err := collection.ByName(c.Params.ByName("name"))
 	if err != nil {
@@ -342,8 +342,8 @@ func apiSnapshotsDiff(c *gin.Context) {
 	onlyMatching := c.Request.URL.Query().Get("onlyMatching") == "1"
 
 	collection := context.CollectionFactory().SnapshotCollection()
-	collection.RLock()
-	defer collection.RUnlock()
+	collection.Lock()
+	defer collection.Unlock()
 
 	snapshotA, err := collection.ByName(c.Params.ByName("name"))
 	if err != nil {
@@ -392,8 +392,8 @@ func apiSnapshotsDiff(c *gin.Context) {
 // GET /api/snapshots/:name/packages
 func apiSnapshotsSearchPackages(c *gin.Context) {
 	collection := context.CollectionFactory().SnapshotCollection()
-	collection.RLock()
-	defer collection.RUnlock()
+	collection.Lock()
+	defer collection.Unlock()
 
 	snapshot, err := collection.ByName(c.Params.ByName("name"))
 	if err != nil {


### PR DESCRIPTION
Fixes #686

## Description of the Change

LoadComplete() modifies object, so it would cause issues if it runs
concurrently with other methods. Uprage mutex locks to write
locks when LoadComplete() is being used.

This reduces concurrency of some API calls but eliminates data races

## Checklist

- [ ] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [x] author name in `AUTHORS`
