### PR TITLE
prevent removal of a PublishedStorage's root dir

### DIFF
--- a/files/public.go
+++ b/files/public.go
@@ -97,12 +97,18 @@ func (storage *PublishedStorage) PutFile(path string, sourceFilename string) err
 
 // Remove removes single file under public path
 func (storage *PublishedStorage) Remove(path string) error {
+	if len(path) <= 0 {
+		panic("trying to remove empty path")
+	}
 	filepath := filepath.Join(storage.rootPath, path)
 	return os.Remove(filepath)
 }
 
 // RemoveDirs removes directory structure under public path
 func (storage *PublishedStorage) RemoveDirs(path string, progress aptly.Progress) error {
+	if len(path) <= 0 {
+		panic("trying to remove the root directory")
+	}
 	filepath := filepath.Join(storage.rootPath, path)
 	if progress != nil {
 		progress.Printf("Removing %s...\n", filepath)

--- a/files/public_test.go
+++ b/files/public_test.go
@@ -320,3 +320,19 @@ func (s *PublishedStorageSuite) TestLinkFromPool(c *C) {
 	err = s.storageCopySize.LinkFromPool(filepath.Join("", "pool", "main", "m/mars-invaders"), "mars-invaders_1.03.deb", pool, srcPoolPath, sourceChecksum, false)
 	c.Check(err, IsNil)
 }
+
+func (s *PublishedStorageSuite) TestRootRemove(c *C) {
+	// Prevent deletion of the root directory by passing empty subpaths.
+
+	pwd := c.MkDir()
+
+	// Symlink
+	linkedDir := filepath.Join(pwd, "linkedDir")
+	os.Symlink(s.root, linkedDir)
+	linkStorage := NewPublishedStorage(linkedDir, "", "")
+	c.Assert(func() { linkStorage.Remove("") }, PanicMatches, "trying to remove empty path")
+
+	// Actual dir
+	dirStorage := NewPublishedStorage(pwd, "", "")
+	c.Assert(func() { dirStorage.RemoveDirs("", nil) }, PanicMatches, "trying to remove the root directory")
+}


### PR DESCRIPTION
## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

presently there is no use case where we need this. on the other hand,
passing empty paths into any of the remove methods is indicative of a bug.
this is particularly dangerous as this can temporarily smash the publish
root but later restore it again when actually publishing. this makes
for super nasty and hard to track down problems.

to guard against this simply disallow root dir removal using empty
strings. should we find a use case for this in the future we can always
revisit this (FTR: I think very explicitly API should be used so everyone
knows what is going on and you can't accidentally run it)

## Checklist

- [x] unit-test added (if change is algorithm)
