### PR TITLE
Fix by by-hash index cleanup + root dir data "loss"

### DIFF
--- a/deb/index_files.go
+++ b/deb/index_files.go
@@ -191,18 +191,19 @@ func packageIndexByHash(file *indexFile, ext string, hash string, sum string) er
 	}
 
 	// if a previous index file already exists exists, backup symlink
-	if exists, _ = file.parent.publishedStorage.FileExists(filepath.Join(dst, indexfile)); exists {
+	indexPath := filepath.Join(dst, indexfile)
+	oldIndexPath := filepath.Join(dst, indexfile+".old")
+	if exists, _ = file.parent.publishedStorage.FileExists(indexPath); exists {
 		// if exists, remove old symlink
-		if exists, _ = file.parent.publishedStorage.FileExists(filepath.Join(dst, indexfile+".old")); exists {
-			var link string
-			link, err = file.parent.publishedStorage.ReadLink(filepath.Join(dst, indexfile+".old"))
+		if exists, _ = file.parent.publishedStorage.FileExists(oldIndexPath); exists {
+			var linkTarget string
+			linkTarget, err = file.parent.publishedStorage.ReadLink(oldIndexPath)
 			if err != nil {
-				file.parent.publishedStorage.Remove(link)
+				file.parent.publishedStorage.Remove(linkTarget)
 			}
-			file.parent.publishedStorage.Remove(filepath.Join(dst, indexfile+".old"))
+			file.parent.publishedStorage.Remove(oldIndexPath)
 		}
-		file.parent.publishedStorage.RenameFile(filepath.Join(dst, indexfile),
-			filepath.Join(dst, indexfile+".old"))
+		file.parent.publishedStorage.RenameFile(indexPath, oldIndexPath)
 	}
 
 	// create symlink

--- a/deb/index_files.go
+++ b/deb/index_files.go
@@ -198,7 +198,10 @@ func packageIndexByHash(file *indexFile, ext string, hash string, sum string) er
 		if exists, _ = file.parent.publishedStorage.FileExists(oldIndexPath); exists {
 			var linkTarget string
 			linkTarget, err = file.parent.publishedStorage.ReadLink(oldIndexPath)
-			if err != nil {
+			if err == nil {
+				// If we managed to resolve the link target: delete it. This is the
+				// oldest physical index file we no longer need. Once we drop our
+				// old symlink we'll essentially forget about it existing at all.
 				file.parent.publishedStorage.Remove(linkTarget)
 			}
 			file.parent.publishedStorage.Remove(oldIndexPath)

--- a/files/public.go
+++ b/files/public.go
@@ -267,7 +267,12 @@ func (storage *PublishedStorage) FileExists(path string) (bool, error) {
 	return true, nil
 }
 
-// ReadLink returns the symbolic link pointed to by path
+// ReadLink returns the symbolic link pointed to by path (relative to storage
+// root)
 func (storage *PublishedStorage) ReadLink(path string) (string, error) {
-	return os.Readlink(path)
+	absPath, err := os.Readlink(filepath.Join(storage.rootPath, path))
+	if err != nil {
+		return absPath, err
+	}
+	return filepath.Rel(storage.rootPath, absPath)
 }

--- a/files/public_test.go
+++ b/files/public_test.go
@@ -129,6 +129,10 @@ func (s *PublishedStorageSuite) TestSymLink(c *C) {
 
 	exists, _ := s.storage.FileExists("ppa/dists/squeeze/InRelease")
 	c.Check(exists, Equals, true)
+
+	linkTarget, err := s.storage.ReadLink("ppa/dists/squeeze/InRelease")
+	c.Assert(err, IsNil)
+	c.Assert(linkTarget, Equals, "ppa/dists/squeeze/Release")
 }
 
 func (s *PublishedStorageSuite) TestHardLink(c *C) {


### PR DESCRIPTION
## Requirements

All new code should be covered with tests, documentation should be updated. CI should pass.

## Description of the Change

the logic here was wrong.
if we managed to find the link target (the physical index file) pointed to
by our old symlink we want to remove it (this is basically "cleaning up old
index" logic).
previously we'd try to only delete it when the ReadLink came back with
error. which had two serious issues with it:

a) linkTarget was empty, so we basically called Remove("") which would
   delete the storage -> root <- directory if the root is a symlink!
b) we'd leak old indexes as the cleanup logic only ran if there was en
   error which would ordinarily never be

new code correctly cleans up unless there was an error.

readlink was also entirely wrong and adjusted to work correctly within the expectations of a publishedstorage

(I presently don't have time to poke around to make the functional test assert that the cleanup works, not sure we really need to care all that much either... I'll probably not get to it this week but this bug is fairly serious as it basically blew up our aptly earlier today)

This also relates to #705 which introduces a guard against part of the underlying problem here (Remove being content with using an empty path)

## Checklist

- [x] unit-test added (if change is algorithm)
- [ ] functional test added/updated (if change is functional)

