### PR TITLE
Implement 'legacy' Contents indexes to match Ubuntu <=16.04

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -56,8 +56,8 @@
     "service/s3",
     "service/sts"
   ]
-  revision = "7f68df2a5baf19398d17def23a514a6e617e5937"
-  version = "v1.13.28"
+  revision = "a72204b9bf8d48230ee0fe8995613b394c66f2da"
+  version = "v1.13.31"
 
 [[projects]]
   name = "github.com/cheggaaa/pb"

--- a/deb/contents.go
+++ b/deb/contents.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/smira/aptly/aptly"
 	"github.com/smira/aptly/database"
 	"github.com/smira/go-uuid/uuid"
 )
@@ -26,10 +25,7 @@ func NewContentsIndex(db database.Storage) *ContentsIndex {
 }
 
 // Push adds package to contents index, calculating package contents as required
-func (index *ContentsIndex) Push(p *Package, packagePool aptly.PackagePool, progress aptly.Progress) error {
-	contents := p.Contents(packagePool, progress)
-	qualifiedName := []byte(p.QualifiedName())
-
+func (index *ContentsIndex) Push(qualifiedName []byte, contents []string) error {
 	for _, path := range contents {
 		// for performance reasons we only write to leveldb during push.
 		// merging of qualified names per path will be done in WriteTo

--- a/deb/index_files.go
+++ b/deb/index_files.go
@@ -329,6 +329,37 @@ func (files *indexFiles) ContentsIndex(component, arch string, udeb bool) *index
 	return file
 }
 
+func (files *indexFiles) LegacyContentsIndex(arch string, udeb bool) *indexFile {
+	if arch == ArchitectureSource {
+		udeb = false
+	}
+	key := fmt.Sprintf("lci-%s-%v", arch, udeb)
+	file, ok := files.indexes[key]
+	if !ok {
+		var relativePath string
+
+		if udeb {
+			relativePath = fmt.Sprintf("Contents-udeb-%s", arch)
+		} else {
+			relativePath = fmt.Sprintf("Contents-%s", arch)
+		}
+
+		file = &indexFile{
+			parent:        files,
+			discardable:   true,
+			compressable:  true,
+			onlyGzip:      true,
+			signable:      false,
+			acquireByHash: files.acquireByHash,
+			relativePath:  relativePath,
+		}
+
+		files.indexes[key] = file
+	}
+
+	return file
+}
+
 func (files *indexFiles) ReleaseFile() *indexFile {
 	return &indexFile{
 		parent:       files,

--- a/system/t06_publish/PublishRepo1Test_contents_i386_legacy
+++ b/system/t06_publish/PublishRepo1Test_contents_i386_legacy
@@ -1,0 +1,3 @@
+FILE LOCATION
+usr/share/doc/libboost-program-options-dev/changelog.gz libdevel/libboost-program-options-dev
+usr/share/doc/libboost-program-options-dev/copyright libdevel/libboost-program-options-dev

--- a/system/t06_publish/repo.py
+++ b/system/t06_publish/repo.py
@@ -54,6 +54,7 @@ class PublishRepo1Test(BaseTest):
         self.check_file_contents('public/dists/maverick/main/source/Sources', 'sources', match_prepare=lambda s: "\n".join(sorted(s.split("\n"))))
         self.check_file_contents('public/dists/maverick/main/binary-i386/Packages', 'binary', match_prepare=lambda s: "\n".join(sorted(s.split("\n"))))
         self.check_file_contents('public/dists/maverick/main/Contents-i386.gz', 'contents_i386', match_prepare=ungzip_if_required)
+        self.check_file_contents('public/dists/maverick/Contents-i386.gz', 'contents_i386_legacy', match_prepare=ungzip_if_required)
 
         # verify signatures
         self.run_cmd(["gpg", "--no-auto-check-trustdb", "--keyring", os.path.join(os.path.dirname(inspect.getsourcefile(BaseTest)), "files", "aptly.pub"),
@@ -92,7 +93,8 @@ class PublishRepo1Test(BaseTest):
 
         if pathsSeen != set(['main/binary-i386/Packages', 'main/binary-i386/Packages.bz2', 'main/binary-i386/Packages.gz',
                              'main/source/Sources', 'main/source/Sources.gz', 'main/source/Sources.bz2',
-                             'main/binary-i386/Release', 'main/source/Release', 'main/Contents-i386.gz']):
+                             'main/binary-i386/Release', 'main/source/Release', 'main/Contents-i386.gz',
+                             'Contents-i386.gz']):
             raise Exception("path seen wrong: %r" % (pathsSeen, ))
 
 
@@ -492,7 +494,7 @@ class PublishRepo17Test(BaseTest):
                              'contrib/source/Sources', 'contrib/source/Sources.gz', 'contrib/source/Sources.bz2',
                              'main/source/Release', 'contrib/source/Release',
                              'main/binary-i386/Release', 'contrib/binary-i386/Release',
-                             'main/Contents-i386.gz']):
+                             'main/Contents-i386.gz', 'Contents-i386.gz']):
             raise Exception("path seen wrong: %r" % (pathsSeen, ))
 
 

--- a/system/t06_publish/snapshot.py
+++ b/system/t06_publish/snapshot.py
@@ -104,7 +104,7 @@ class PublishSnapshot1Test(BaseTest):
         if pathsSeen != set(['main/binary-amd64/Packages', 'main/binary-i386/Packages', 'main/binary-i386/Packages.gz',
                              'main/binary-amd64/Packages.gz', 'main/binary-amd64/Packages.bz2', 'main/binary-i386/Packages.bz2',
                              'main/binary-amd64/Release', 'main/binary-i386/Release', 'main/Contents-amd64.gz',
-                             'main/Contents-i386.gz']):
+                             'main/Contents-i386.gz', 'Contents-i386.gz', 'Contents-amd64.gz']):
             raise Exception("path seen wrong: %r" % (pathsSeen, ))
 
 
@@ -754,7 +754,8 @@ class PublishSnapshot26Test(BaseTest):
                              'contrib/source/Sources', 'contrib/source/Sources.gz', 'contrib/source/Sources.bz2',
                              'main/binary-amd64/Release', 'main/binary-i386/Release', 'main/source/Release',
                              'contrib/binary-amd64/Release', 'contrib/binary-i386/Release', 'contrib/source/Release',
-                             'contrib/Contents-i386.gz', 'main/Contents-i386.gz', 'main/Contents-amd64.gz']):
+                             'contrib/Contents-i386.gz', 'main/Contents-i386.gz', 'main/Contents-amd64.gz',
+                             'Contents-i386.gz', 'Contents-amd64.gz']):
             raise Exception("path seen wrong: %r" % (pathsSeen, ))
 
 
@@ -975,6 +976,7 @@ class PublishSnapshot35Test(BaseTest):
                     pathsExepcted.add("main/%sbinary-%s/Packages%s" % (udeb, arch, ext))
 
                 pathsExepcted.add("main/Contents-%s%s.gz" % ("udeb-" if udeb != "" else "", arch))
+                pathsExepcted.add("Contents-%s%s.gz" % ("udeb-" if udeb != "" else "", arch))
 
                 pathsExepcted.add("main/%sbinary-%s/Release" % (udeb, arch))
 

--- a/system/t06_publish/switch.py
+++ b/system/t06_publish/switch.py
@@ -86,7 +86,7 @@ class PublishSwitch1Test(BaseTest):
         if pathsSeen != set(['main/binary-amd64/Packages', 'main/binary-i386/Packages', 'main/binary-i386/Packages.gz',
                              'main/binary-amd64/Packages.gz', 'main/binary-amd64/Packages.bz2', 'main/binary-i386/Packages.bz2',
                              'main/binary-amd64/Release', 'main/binary-i386/Release', 'main/Contents-amd64.gz',
-                             'main/Contents-i386.gz']):
+                             'main/Contents-i386.gz', 'Contents-i386.gz', 'Contents-amd64.gz']):
             raise Exception("path seen wrong: %r" % (pathsSeen, ))
 
 
@@ -354,7 +354,7 @@ class PublishSwitch8Test(BaseTest):
                              'a/binary-i386/Release', 'b/binary-i386/Release', 'c/binary-i386/Release',
                              'a/source/Release', 'b/source/Release', 'c/source/Release',
                              'b/Contents-amd64.gz', 'c/Contents-i386.gz', 'a/Contents-i386.gz',
-                             'a/Contents-amd64.gz', 'b/Contents-i386.gz']):
+                             'a/Contents-amd64.gz', 'b/Contents-i386.gz', 'Contents-i386.gz', 'Contents-amd64.gz']):
             raise Exception("path seen wrong: %r" % (pathsSeen, ))
 
 
@@ -531,5 +531,5 @@ class PublishSwitch14Test(BaseTest):
         if pathsSeen != set(['main/binary-amd64/Packages', 'main/binary-i386/Packages', 'main/binary-i386/Packages.gz',
                              'main/binary-amd64/Packages.gz', 'main/binary-amd64/Packages.bz2', 'main/binary-i386/Packages.bz2',
                              'main/binary-amd64/Release', 'main/binary-i386/Release', 'main/Contents-amd64.gz',
-                             'main/Contents-i386.gz']):
+                             'main/Contents-i386.gz', 'Contents-i386.gz', 'Contents-amd64.gz']):
             raise Exception("path seen wrong: %r" % (pathsSeen, ))

--- a/system/t06_publish/update.py
+++ b/system/t06_publish/update.py
@@ -31,6 +31,7 @@ class PublishUpdate1Test(BaseTest):
         self.check_exists('public/dists/maverick/main/binary-i386/Packages')
         self.check_exists('public/dists/maverick/main/binary-i386/Packages.gz')
         self.check_exists('public/dists/maverick/main/binary-i386/Packages.bz2')
+        self.check_exists('public/dists/maverick/Contents-i386.gz')
         self.check_exists('public/dists/maverick/main/Contents-i386.gz')
         self.check_exists('public/dists/maverick/main/source/Sources')
         self.check_exists('public/dists/maverick/main/source/Sources.gz')
@@ -84,7 +85,8 @@ class PublishUpdate1Test(BaseTest):
 
         if pathsSeen != set(['main/binary-i386/Packages', 'main/binary-i386/Packages.bz2', 'main/binary-i386/Packages.gz',
                              'main/source/Sources', 'main/source/Sources.gz', 'main/source/Sources.bz2',
-                             'main/binary-i386/Release', 'main/source/Release', 'main/Contents-i386.gz']):
+                             'main/binary-i386/Release', 'main/source/Release', 'main/Contents-i386.gz',
+                             'Contents-i386.gz']):
             raise Exception("path seen wrong: %r" % (pathsSeen, ))
 
 
@@ -370,6 +372,7 @@ class PublishUpdate12Test(BaseTest):
         self.check_exists('public/dists/maverick/main/binary-i386/Packages')
         self.check_exists('public/dists/maverick/main/binary-i386/Packages.gz')
         self.check_exists('public/dists/maverick/main/binary-i386/Packages.bz2')
+        self.check_exists('public/dists/maverick/Contents-i386.gz')
         self.check_exists('public/dists/maverick/main/Contents-i386.gz')
         self.check_exists('public/dists/maverick/main/source/Sources')
         self.check_exists('public/dists/maverick/main/source/Sources.gz')
@@ -423,5 +426,6 @@ class PublishUpdate12Test(BaseTest):
 
         if pathsSeen != set(['main/binary-i386/Packages', 'main/binary-i386/Packages.bz2', 'main/binary-i386/Packages.gz',
                              'main/source/Sources', 'main/source/Sources.gz', 'main/source/Sources.bz2',
-                             'main/binary-i386/Release', 'main/source/Release', 'main/Contents-i386.gz']):
+                             'main/binary-i386/Release', 'main/source/Release', 'main/Contents-i386.gz',
+                             'Contents-i386.gz']):
             raise Exception("path seen wrong: %r" % (pathsSeen, ))


### PR DESCRIPTION
Another index is created which unifies data for all the components.

This certainly requires more resources as we have to build yet another
index.

Fixes #667 

## Checklist

- [ ] unit-test added (if change is algorithm)
- [x] functional test added/updated (if change is functional)
- [ ] man page updated (if applicable)
- [ ] bash completion updated (if applicable)
- [ ] documentation updated
- [ ] author name in `AUTHORS`
