### PR TITLE
Change build settings to speed up builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,7 @@ _testmain.go
 *.exe
 *.test
 
-coverage.html
-coverage*.out
+coverage.txt
 
 *.pyc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,6 @@ sudo: required
 
 language: go
 
-go:
-  - 1.8.x
-  - 1.9.x
-  - 1.10.x
-  - master
-
 go_import_path: github.com/smira/aptly
 
 addons:
@@ -19,11 +13,26 @@ addons:
 
 env:
   global:
-    - secure: "YSwtFrMqh4oUvdSQTXBXMHHLWeQgyNEL23ChIZwU0nuDGIcQZ65kipu0PzefedtUbK4ieC065YCUi4UDDh6gPotB/Wu1pnYg3dyQ7rFvhaVYAAUEpajAdXZhlx+7+J8a4FZMeC/kqiahxoRgLbthF9019ouIqhGB9zHKI6/yZwc="
     - secure: "EcCzJsqQ3HnIkprBPS1YHErsETcb7KQFBYEzVDE7RYDApWeapLq+r/twMtWMd/fkGeLzr3kWSg7nhSadeHMLYeMl9j+U7ncC5CWG5NMBOj/jowlb9cMCCDlmzMoZLAgR6jm1cJyrWCLsWVlv+D0ZiB0fx4xaBZP/gIr9g6nEwC8="
     - secure: "OxiVNmre2JzUszwPNNilKDgIqtfX2gnRSsVz6nuySB1uO2yQsOQmKWJ9cVYgH2IB5H8eWXKOhexcSE28kz6TPLRuEcU9fnqKY3uEkdwm7rJfz9lf+7C4bJEUdA1OIzJppjnWUiXxD7CEPL1DlnMZM24eDQYqa/4WKACAgkK53gE="
     - NO_FTP_ACCESS: "yes"
     - BOTO_CONFIG: /dev/null
+
+matrix:
+  allow_failures:
+    - go: master
+      env: RUN_LONG_TESTS=no
+  fast_finish: true
+  include:
+    - go: 1.8.x
+      env: RUN_LONG_TESTS=no
+    - go: 1.9.x
+      env: RUN_LONG_TESTS=yes
+    - go: 1.10.x
+      env: RUN_LONG_TESTS=yes
+    - go: master
+      env: RUN_LONG_TESTS=no
+
 before_install:
   - virtualenv system/env
   - . system/env/bin/activate
@@ -31,14 +40,12 @@ before_install:
   - pip install -U pip setuptools
   - pip install -r system/requirements.txt
   - make version
+
 install:
   - make prepare
 
-script: make travis
-
-matrix:
-    allow_failures:
-        - go: master
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
 
 notifications:
   webhooks:

--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ aptly
 .. image:: https://api.travis-ci.org/smira/aptly.svg?branch=master
     :target: https://travis-ci.org/smira/aptly
 
-.. image:: https://coveralls.io/repos/smira/aptly/badge.svg?branch=master
-    :target: https://coveralls.io/r/smira/aptly?branch=master
+.. image:: https://codecov.io/gh/smira/aptly/branch/master/graph/badge.svg
+  :target: https://codecov.io/gh/smira/aptly
 
 .. image:: https://badges.gitter.im/Join Chat.svg
     :target: https://gitter.im/smira/aptly?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge


### PR DESCRIPTION
1. Don't run long steps for Go versions other than 1.9 & 1.10
according to Golang Release Policy (two latest versions).

2. Switch to codecov.io, collect coverage only on Go 1.10 which
has fixes for multi-module coverage & ./... ignoring vendor.

3. Simplify Makefile.

